### PR TITLE
Prevent crash when something stabby happens

### DIFF
--- a/Automattic-Tracks-iOS/TracksEventPersistenceService.m
+++ b/Automattic-Tracks-iOS/TracksEventPersistenceService.m
@@ -73,7 +73,11 @@
         for (TracksEvent *tracksEvent in tracksEvents) {
             TracksEventCoreData *tracksEventCoreData = [self findTracksEventCoreDataWithUUID:tracksEvent.uuid];
             
-            [self.managedObjectContext deleteObject:tracksEventCoreData];
+            if (tracksEventCoreData) {
+                [self.managedObjectContext deleteObject:tracksEventCoreData];
+            } else {
+                DDLogWarn(@"No TracksEventCoreData instance found with UUID: %@", tracksEvent.uuid);
+            }
         }
         
         [self saveManagedObjectContext];


### PR DESCRIPTION
Closes #7 

When no event is found with a particular UUID, don't delete nil.