### PR TITLE
Tracks Client crash on iOS 7 with unrecognized selector

### DIFF
--- a/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
+++ b/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
@@ -520,6 +520,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 792B829D0A23395238AF6CAB /* Pods-Automattic-Tracks-iOS.debug.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -529,6 +530,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7C14B632CA74A30467DE3176 /* Pods-Automattic-Tracks-iOS.release.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -547,6 +549,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Automattic-Tracks-iOSTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -561,6 +564,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Automattic-Tracks-iOSTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/Automattic-Tracks-iOS/TracksEvent.m
+++ b/Automattic-Tracks-iOS/TracksEvent.m
@@ -64,7 +64,7 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
         }
         
         return NO;
-    } else if ([(NSString *)*ioValue containsString:@"-"]) {
+    } else if ([(NSString *)*ioValue rangeOfString:@"-"].location != NSNotFound) {
         if (outError != NULL) {
             NSString *errorString = NSLocalizedString(@"An event name must not contain dashes.",
                                                       @"validation: TracksEvent, contains dashes eventName error");


### PR DESCRIPTION
Fixes #10 

Use a method available in iOS 7 to determine if a string contains a dash character. Also updated the deployment target to iOS 7 from base (currently 8.2) to allow unit tests to find these problems in the future.