### PR TITLE
Wrap all public persistence methods in performBlockAndWait

### DIFF
--- a/Automattic-Tracks-iOS/TracksEventPersistenceService.m
+++ b/Automattic-Tracks-iOS/TracksEventPersistenceService.m
@@ -32,21 +32,25 @@
 
 - (NSArray *)fetchAllTracksEvents
 {
-    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"TracksEvent"];
+    __block NSMutableArray *transformedResults;
     
-    NSError *error;
-    NSArray *results = [self.managedObjectContext executeFetchRequest:fetchRequest error:&error];
-    
-    if (error) {
-        DDLogError(@"Error while fetching all TracksEvent: %@", error);
-        return nil;
-    }
-    
-    NSMutableArray *transformedResults = [[NSMutableArray alloc] initWithCapacity:results.count];
-    for (TracksEventCoreData *eventCoreData in results) {
-        TracksEvent *tracksEvent = [self mapToTracksEventWithTracksEventCoreData:eventCoreData];
-        [transformedResults addObject:tracksEvent];
-    }
+    [self.managedObjectContext performBlockAndWait:^{
+        NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"TracksEvent"];
+        
+        NSError *error;
+        NSArray *results = [self.managedObjectContext executeFetchRequest:fetchRequest error:&error];
+        
+        if (error) {
+            DDLogError(@"Error while fetching all TracksEvent: %@", error);
+            return;
+        }
+        
+        transformedResults = [[NSMutableArray alloc] initWithCapacity:results.count];
+        for (TracksEventCoreData *eventCoreData in results) {
+            TracksEvent *tracksEvent = [self mapToTracksEventWithTracksEventCoreData:eventCoreData];
+            [transformedResults addObject:tracksEvent];
+        }
+    }];
     
     return transformedResults;
 }
@@ -54,14 +58,18 @@
 
 - (NSUInteger)countAllTracksEvents
 {
-    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"TracksEvent"];
+    __block NSUInteger count = 0;
     
-    NSError *error;
-    NSUInteger count = [self.managedObjectContext countForFetchRequest:fetchRequest error:&error];
-    
-    if (error) {
-        DDLogError(@"Error while fetching count of TracksEvent: %@", error);
-    }
+    [self.managedObjectContext performBlockAndWait:^{
+        NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"TracksEvent"];
+        
+        NSError *error;
+        count = [self.managedObjectContext countForFetchRequest:fetchRequest error:&error];
+        
+        if (error) {
+            DDLogError(@"Error while fetching count of TracksEvent: %@", error);
+        }
+    }];
     
     return count;
 }

--- a/TracksDemo/Podfile.lock
+++ b/TracksDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Automattic-Tracks-iOS (0.0.3):
+  - Automattic-Tracks-iOS (0.0.4):
     - CocoaLumberjack (~> 2.0)
     - UIDeviceIdentifier (~> 0.4)
   - CocoaLumberjack (2.0.0):
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Automattic-Tracks-iOS: a19a0e9cf6c6b788d1c8ac89eda08855c4fd5ce9
+  Automattic-Tracks-iOS: 41e28904cae548a5065887778e51e084888ab93e
   CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
   UIDeviceIdentifier: 2eb1070f189a069184611e21b5e8832443e6f8ec
 


### PR DESCRIPTION
Fixes #16 

Wrap all persistence methods with `performBlockAndWait:` to make sure they're executed with some thread safety. This isn't a huge deal for WPiOS since the tracker thread is on its own thread but it prevents problems.

Needs Review: @SergioEstevao 