### PR TITLE
Use a constant for setting the podspec version

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |spec|
   spec.framework    = 'CoreTelephony'
 
   spec.dependency 'UIDeviceIdentifier', '~> 0.4'
-  spec.dependency 'CocoaLumberjack', '~> 2.0'
+  spec.dependency 'CocoaLumberjack', '2.0.0'
 end

--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'Automattic-Tracks-iOS'
-  spec.version      = '0.0.5'
+  spec.version      = File.read("Automattic-Tracks-iOS/TracksConstants.m").split("const TracksLibraryVersion = @\"").last.split("\"").first
   spec.platform     = :ios, "7.0"
   spec.license      = { :type => 'GPLv2' }
   spec.homepage     = 'https://github.com/automattic/automattic-tracks-ios'

--- a/Automattic-Tracks-iOS/TracksConstants.h
+++ b/Automattic-Tracks-iOS/TracksConstants.h
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 
 FOUNDATION_EXPORT NSString *const TracksErrorDomain;
+FOUNDATION_EXPORT NSString *const TracksLibraryVersion;
 
 typedef NS_ENUM(NSInteger, TracksErrorCode) {
     TracksErrorCodeValidationEventNameMissing,

--- a/Automattic-Tracks-iOS/TracksConstants.m
+++ b/Automattic-Tracks-iOS/TracksConstants.m
@@ -1,3 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
+NSString *const TracksLibraryVersion = @"0.0.5";

--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -245,7 +245,7 @@ NSString *const USER_ID_ANON = @"anonId";
               DeviceHeightPixelsKey : @(screenSize.height) ?: @0,
               DeviceWidthPixelsKey : @(screenSize.width) ?: @0,
               DeviceLanguageKey : deviceInformation.deviceLanguage ?: @"Unknown",
-              TracksUserAgentKey : @"Nosara Client for iOS 0.0.0",
+              TracksUserAgentKey : [NSString stringWithFormat:@"Nosara Client for iOS %@", TracksLibraryVersion],
               };
 }
 

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@
 
 target 'Automattic-Tracks-iOS' do
   pod 'UIDeviceIdentifier', '~> 0.4'
-  pod 'CocoaLumberjack', '~> 2.0'
+  pod 'CocoaLumberjack', '2.0.0'
 end
 
 target 'Automattic-Tracks-iOSTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - UIDeviceIdentifier (0.4.4)
 
 DEPENDENCIES:
-  - CocoaLumberjack (~> 2.0)
+  - CocoaLumberjack (= 2.0.0)
   - OCMock
   - UIDeviceIdentifier (~> 0.4)
 

--- a/TracksDemo/Podfile.lock
+++ b/TracksDemo/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Automattic-Tracks-iOS (0.0.5):
-    - CocoaLumberjack (~> 2.0)
+    - CocoaLumberjack (= 2.0.0)
     - UIDeviceIdentifier (~> 0.4)
   - CocoaLumberjack (2.0.0):
     - CocoaLumberjack/Default (= 2.0.0)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Automattic-Tracks-iOS: ab220f67739e830d00dffb2caa4962e19dbde373
+  Automattic-Tracks-iOS: 5fb3f1158084bc99b738ddfec1d0072601947af2
   CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
   UIDeviceIdentifier: 2eb1070f189a069184611e21b5e8832443e6f8ec
 


### PR DESCRIPTION
Closes #20 

Establishes a version number for the library in TracksConstants.h/m which can be used in `TracksDeviceInformation` when sending events into the Nosara Tracks system. This same version number is now pulled into the podspec so the version number lives only in one place. Updating the version forces the constant to be updated.

Needs Review: @daniloercoli, @jleandroperez 

Thanks to @orta for the help coming up with this idea!