### PR TITLE
Sets user agent on events properly and also now on URL connection

### DIFF
--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -8,6 +8,7 @@
 @property (nonatomic, assign) BOOL timerEnabled;
 @property (nonatomic, strong) TracksContextManager *contextManager;
 
+@property (nonatomic, readonly) NSString *userAgent;
 @property (nonatomic, copy) NSString *username;
 @property (nonatomic, copy) NSString *userID;
 @property (nonatomic, assign, getter=isAnonymous) BOOL anonymous;
@@ -54,6 +55,7 @@ NSString *const USER_ID_ANON = @"anonId";
     if (self) {
         _eventNamePrefix = @"wpios";
         _remote = [TracksServiceRemote new];
+        _remote.tracksUserAgent = self.userAgent;
         _queueSendInterval = EVENT_TIMER_DEFAULT;
         _contextManager = contextManager;
         _tracksEventService = [[TracksEventService alloc] initWithContextManager:contextManager];
@@ -84,7 +86,7 @@ NSString *const USER_ID_ANON = @"anonId";
     [self.tracksEventService createTracksEventWithName:eventName
                                               username:self.username
                                                 userID:self.userID
-                                             userAgent:nil
+                                             userAgent:self.userAgent
                                               userType:self.isAnonymous ? TracksEventUserTypeAnonymous : TracksEventUserTypeWordPressCom
                                              eventDate:[NSDate date]
                                       customProperties:customProperties
@@ -245,7 +247,7 @@ NSString *const USER_ID_ANON = @"anonId";
               DeviceHeightPixelsKey : @(screenSize.height) ?: @0,
               DeviceWidthPixelsKey : @(screenSize.width) ?: @0,
               DeviceLanguageKey : deviceInformation.deviceLanguage ?: @"Unknown",
-              TracksUserAgentKey : [NSString stringWithFormat:@"Nosara Client for iOS %@", TracksLibraryVersion],
+              TracksUserAgentKey : self.userAgent,
               };
 }
 
@@ -305,6 +307,11 @@ NSString *const USER_ID_ANON = @"anonId";
     }
     
     return dict;
+}
+
+- (NSString *)userAgent
+{
+    return [NSString stringWithFormat:@"Nosara Client for iOS %@", TracksLibraryVersion];
 }
 
 @end

--- a/Automattic-Tracks-iOS/TracksServiceRemote.h
+++ b/Automattic-Tracks-iOS/TracksServiceRemote.h
@@ -3,6 +3,8 @@
 
 @interface TracksServiceRemote : NSObject
 
+@property (nonatomic, strong) NSString *tracksUserAgent;
+
 - (void)sendBatchOfEvents:(NSArray *)events withSharedProperties:(NSDictionary *)properties completionHandler:(void (^)(NSError *error))completion;
 
 @end

--- a/Automattic-Tracks-iOS/TracksServiceRemote.m
+++ b/Automattic-Tracks-iOS/TracksServiceRemote.m
@@ -13,6 +13,10 @@
     [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     [request addValue:@"application/json" forHTTPHeaderField:@"Accept"];
     
+    if (self.tracksUserAgent) {
+        [request setValue:self.tracksUserAgent forHTTPHeaderField:@"User-Agent"];
+    }
+    
     NSURLSession *sharedSession = [NSURLSession sharedSession];
     
     NSURLSessionDataTask *task;


### PR DESCRIPTION
Closes #21 

Sets the user agent on all of the tracks events. It was not being set but the functionality was there - it was an incomplete feature. The current user agent is still being used in the parent property calculation.

The user agent is also now being set on the NSURLConnection used to connect to the REST endpoint.

Not entirely sure what the best approach is to test this other than reviewing the events sent to Tracks or inspecting with Charles Proxy.

Needs Review: @aerych, @daniloercoli 