### PR TITLE
Prevent long variable memory problems on 32-bit processors

### DIFF
--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -234,8 +234,9 @@ NSString *const USER_ID_ANON = @"anonId";
     TracksDeviceInformation *deviceInformation = [TracksDeviceInformation new];
     
     CGSize screenSize = [[UIScreen mainScreen] bounds].size;
-    
-    return @{ RequestTimestampKey : [NSString stringWithFormat:@"%1.0f000", [NSDate date].timeIntervalSince1970],
+    long long since1970millis = [NSDate date].timeIntervalSince1970 * 1000;
+
+    return @{ RequestTimestampKey : @(since1970millis),
               DeviceInfoAppBuildKey : deviceInformation.appBuild ?: @"Unknown",
               DeviceInfoAppNameKey : deviceInformation.appName ?: @"Unknown",
               DeviceInfoAppVersionKey : deviceInformation.appVersion ?: @"Unknown",
@@ -264,9 +265,12 @@ NSString *const USER_ID_ANON = @"anonId";
 
 - (NSDictionary *)dictionaryForTracksEvent:(TracksEvent *)tracksEvent withParentCommonProperties:(NSDictionary *)parentCommonProperties
 {
+    NSTimeInterval since1970 = tracksEvent.date.timeIntervalSince1970;
+    long long since1970millis = since1970 * 1000;
+    
     NSMutableDictionary *dict = [NSMutableDictionary new];
     dict[TracksEventNameKey] = tracksEvent.eventName;
-    dict[TracksTimestampKey] = [NSString stringWithFormat:@"%1.0f000", tracksEvent.date.timeIntervalSince1970];
+    dict[TracksTimestampKey] = @(since1970millis);
     
     if (tracksEvent.userType == TracksEventUserTypeAnonymous) {
         dict[TracksUserTypeKey] = TracksUserTypeAnonymous;

--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -235,7 +235,7 @@ NSString *const USER_ID_ANON = @"anonId";
     
     CGSize screenSize = [[UIScreen mainScreen] bounds].size;
     
-    return @{ RequestTimestampKey : @(lround([NSDate date].timeIntervalSince1970 * 1000)),
+    return @{ RequestTimestampKey : [NSString stringWithFormat:@"%1.0f000", [NSDate date].timeIntervalSince1970],
               DeviceInfoAppBuildKey : deviceInformation.appBuild ?: @"Unknown",
               DeviceInfoAppNameKey : deviceInformation.appName ?: @"Unknown",
               DeviceInfoAppVersionKey : deviceInformation.appVersion ?: @"Unknown",
@@ -266,7 +266,7 @@ NSString *const USER_ID_ANON = @"anonId";
 {
     NSMutableDictionary *dict = [NSMutableDictionary new];
     dict[TracksEventNameKey] = tracksEvent.eventName;
-    dict[TracksTimestampKey] = @(lround(tracksEvent.date.timeIntervalSince1970 * 1000));
+    dict[TracksTimestampKey] = [NSString stringWithFormat:@"%1.0f000", tracksEvent.date.timeIntervalSince1970];
     
     if (tracksEvent.userType == TracksEventUserTypeAnonymous) {
         dict[TracksUserTypeKey] = TracksUserTypeAnonymous;


### PR DESCRIPTION
Closes #28 

On 32-bit devices it seems that our calculation for milliseconds since 1970 is too long to fit into memory. Instead of multiplying the double by 1000 to get a long, format the number and pad with three zeros.

Needs Review: @jleandroperez 