### PR TITLE
Implements OS X Support

### DIFF
--- a/Automattic-Tracks-OSX.podspec
+++ b/Automattic-Tracks-OSX.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |spec|
+  spec.name         = 'Automattic-Tracks-OSX'
+  spec.version      = File.read("Automattic-Tracks-iOS/TracksConstants.m").split("const TracksLibraryVersion = @\"").last.split("\"").first
+  spec.platform     = :osx, "10.8"
+  spec.license      = { :type => 'GPLv2' }
+  spec.homepage     = 'https://github.com/automattic/automattic-tracks-ios'
+  spec.authors      = { 'Aaron Douglas' => 'aaron@automattic.com' }
+  spec.summary      = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
+  spec.source       = { :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => spec.version.to_s }
+  spec.source_files = 'Automattic-Tracks-iOS/**/*.{h,m}'
+  spec.resource_bundle = { 'DataModel' => ['Automattic-Tracks-iOS/**/*.xcdatamodeld'] }
+  spec.framework    = 'CoreData'
+  spec.framework    = 'CoreTelephony'
+
+  spec.dependency 'CocoaLumberjack', '2.0.0'
+  spec.dependency 'Reachability', '~>3.1'
+end

--- a/Automattic-Tracks-iOS/TracksDeviceInformation.h
+++ b/Automattic-Tracks-iOS/TracksDeviceInformation.h
@@ -1,4 +1,4 @@
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 @interface TracksDeviceInformation : NSObject
 

--- a/Automattic-Tracks-iOS/TracksDeviceInformation.m
+++ b/Automattic-Tracks-iOS/TracksDeviceInformation.m
@@ -1,7 +1,13 @@
 #import "TracksDeviceInformation.h"
+#import <UIDeviceIdentifier/UIDeviceHardware.h>
+
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #import <CoreTelephony/CTCarrier.h>
-#import <UIDeviceHardware.h>
+#else
+#import <AppKit/AppKit.h>
+#endif
 
 @interface TracksDeviceInformation ()
 
@@ -27,6 +33,13 @@
     return @"Apple";
 }
 
+- (NSString *)manufacturer
+{
+    return @"Apple";
+}
+
+
+#if TARGET_OS_IPHONE
 
 - (NSString *)currentNetworkOperator
 {
@@ -59,13 +72,6 @@
     return [[NSLocale currentLocale] localeIdentifier];
 }
 
-
-- (NSString *)manufacturer
-{
-    return @"Apple";
-}
-
-
 - (NSString *)model
 {
     return [UIDeviceHardware platformString];
@@ -82,6 +88,45 @@
 {
     return [[UIDevice currentDevice] systemVersion];
 }
+
+#else
+
+- (NSString *)currentNetworkOperator
+{
+    return @"";
+}
+
+
+- (NSString *)currentNetworkRadioType
+{
+    return @"";
+}
+
+
+- (NSString *)deviceLanguage
+{
+    return [[NSLocale currentLocale] localeIdentifier];
+}
+
+- (NSString *)model
+{
+    return [UIDeviceHardware platform];
+}
+
+
+- (NSString *)os
+{
+    return @"OS X";
+}
+
+
+- (NSString *)version
+{
+    return [[NSProcessInfo processInfo] operatingSystemVersionString];
+}
+
+#endif
+
 
 
 #pragma mark - App Specific Information

--- a/Automattic-Tracks-iOS/TracksDeviceInformation.m
+++ b/Automattic-Tracks-iOS/TracksDeviceInformation.m
@@ -1,8 +1,8 @@
 #import "TracksDeviceInformation.h"
-#import <UIDeviceIdentifier/UIDeviceHardware.h>
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
+#import <UIDeviceIdentifier/UIDeviceHardware.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #import <CoreTelephony/CTCarrier.h>
 #else
@@ -110,7 +110,7 @@
 
 - (NSString *)model
 {
-    return [UIDeviceHardware platform];
+    return @"";
 }
 
 

--- a/Automattic-Tracks-iOS/TracksService.h
+++ b/Automattic-Tracks-iOS/TracksService.h
@@ -1,4 +1,4 @@
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 #import "TracksEvent.h"
 #import "TracksEventService.h"
 #import "TracksServiceRemote.h"

--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -3,6 +3,13 @@
 #import <CocoaLumberjack/CocoaLumberjack.h>
 #import <Reachability/Reachability.h>
 
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#else
+#import <AppKit/AppKit.h>
+#endif
+
+
 @interface TracksService ()
 
 @property (nonatomic, strong) NSTimer *timer;
@@ -74,10 +81,12 @@ NSString *const USER_ID_ANON = @"anonId";
         [self resetTimer];
         
         NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
+        [defaultCenter addObserver:self selector:@selector(reachabilityChanged:) name:kReachabilityChangedNotification object:nil];
+        
+#if TARGET_OS_IPHONE
         [defaultCenter addObserver:self selector:@selector(didEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
         [defaultCenter addObserver:self selector:@selector(didBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
-        
-        [defaultCenter addObserver:self selector:@selector(reachabilityChanged:) name:kReachabilityChangedNotification object:nil];
+#endif
     }
     return self;
 }
@@ -267,7 +276,12 @@ NSString *const USER_ID_ANON = @"anonId";
 
 - (NSDictionary *)immutableDeviceProperties
 {
+#if TARGET_OS_IPHONE
     CGSize screenSize = [[UIScreen mainScreen] bounds].size;
+#else
+    CGSize screenSize = [[NSScreen mainScreen] frame].size;
+#endif
+    
     long long since1970millis = [NSDate date].timeIntervalSince1970 * 1000;
 
     return @{ RequestTimestampKey : @(since1970millis),

--- a/Automattic-Tracks-iOSTests/TracksEventServiceTests.m
+++ b/Automattic-Tracks-iOSTests/TracksEventServiceTests.m
@@ -1,4 +1,4 @@
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 #import <OCMock/OCMock.h>
 #import "TracksEventService.h"


### PR DESCRIPTION
#### Steps:
1. Edit (LOCALLY) the podspec.source so that it maps to `:branch => 'issues/osx-support'` 
2. Validate OSX spec: `pod spec lint Automattic-Tracks-OSX.podspec  --allow-warnings`
3. Validate iOS spec: `pod spec lint Automattic-Tracks-iOS.podspec  --allow-warnings`

Needs Review: @astralbodies 