### PR TITLE
Dynamic User Type

### DIFF
--- a/Automattic-Tracks-iOS/TracksEvent.h
+++ b/Automattic-Tracks-iOS/TracksEvent.h
@@ -3,7 +3,7 @@
 
 typedef NS_ENUM(NSUInteger, TracksEventUserType) {
     TracksEventUserTypeAnonymous,
-    TracksEventUserTypeWordPressCom,
+    TracksEventUserTypeAuthenticated,
 };
 
 @interface TracksEvent : NSObject

--- a/Automattic-Tracks-iOS/TracksEventService.m
+++ b/Automattic-Tracks-iOS/TracksEventService.m
@@ -71,7 +71,7 @@
     tracksEvent.customProperties[@"anonId"] = anonymousUserID;
     tracksEvent.username = username;
     tracksEvent.userID = userID;
-    tracksEvent.userType = TracksEventUserTypeWordPressCom;
+    tracksEvent.userType = TracksEventUserTypeAuthenticated;
     tracksEvent.date = [NSDate date];
     
     [self.persistenceService persistTracksEvent:tracksEvent];

--- a/Automattic-Tracks-iOS/TracksService.h
+++ b/Automattic-Tracks-iOS/TracksService.h
@@ -12,6 +12,8 @@ extern NSString *const TrackServiceDidSendQueuedEventsNotification;
 @property (nonatomic, strong) TracksServiceRemote *remote;
 
 @property (nonatomic, copy) NSString *eventNamePrefix;
+@property (nonatomic, copy) NSString *anonymousUserType;
+@property (nonatomic, copy) NSString *authenticatedUserType;
 
 @property (nonatomic, assign) NSTimeInterval queueSendInterval;
 @property (nonatomic, readonly) NSUInteger queuedEventCount;

--- a/Automattic-Tracks-iOS/TracksService.h
+++ b/Automattic-Tracks-iOS/TracksService.h
@@ -12,8 +12,8 @@ extern NSString *const TrackServiceDidSendQueuedEventsNotification;
 @property (nonatomic, strong) TracksServiceRemote *remote;
 
 @property (nonatomic, copy) NSString *eventNamePrefix;
-@property (nonatomic, copy) NSString *anonymousUserType;
-@property (nonatomic, copy) NSString *authenticatedUserType;
+@property (nonatomic, copy) NSString *anonymousUserTypeKey;
+@property (nonatomic, copy) NSString *authenticatedUserTypeKey;
 
 @property (nonatomic, assign) NSTimeInterval queueSendInterval;
 @property (nonatomic, readonly) NSUInteger queuedEventCount;

--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -65,8 +65,8 @@ NSString *const USER_ID_ANON = @"anonId";
     self = [super init];
     if (self) {
         _eventNamePrefix = @"wpios";
-        _anonymousUserType = TracksUserTypeAnonymous;
-        _authenticatedUserType = TracksUserTypeAuthenticated;
+        _anonymousUserTypeKey = TracksUserTypeAnonymous;
+        _authenticatedUserTypeKey = TracksUserTypeAuthenticated;
         _remote = [TracksServiceRemote new];
         _remote.tracksUserAgent = self.userAgent;
         _queueSendInterval = EVENT_TIMER_DEFAULT;
@@ -323,10 +323,10 @@ NSString *const USER_ID_ANON = @"anonId";
     dict[TracksTimestampKey] = @(since1970millis);
     
     if (tracksEvent.userType == TracksEventUserTypeAnonymous) {
-        dict[TracksUserTypeKey] = self.anonymousUserType;
+        dict[TracksUserTypeKey] = self.anonymousUserTypeKey;
         dict[TracksUserIDKey] = tracksEvent.userID;
     } else {
-        dict[TracksUserTypeKey] = self.authenticatedUserType;
+        dict[TracksUserTypeKey] = self.authenticatedUserTypeKey;
         dict[TracksUserIDKey] = tracksEvent.userID;
         dict[TracksUsernameKey] = tracksEvent.username;
     }

--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -54,7 +54,7 @@ NSString *const TracksUserIDKey = @"_ui";
 NSString *const TracksUsernameKey = @"_ul";
 
 NSString *const TracksUserTypeAnonymous = @"anon";
-NSString *const TracksUserTypeWPCOM = @"wpcom:user_id";
+NSString *const TracksUserTypeAuthenticated = @"wpcom:user_id";
 NSString *const USER_ID_ANON = @"anonId";
 
 
@@ -65,6 +65,8 @@ NSString *const USER_ID_ANON = @"anonId";
     self = [super init];
     if (self) {
         _eventNamePrefix = @"wpios";
+        _anonymousUserType = TracksUserTypeAnonymous;
+        _authenticatedUserType = TracksUserTypeAuthenticated;
         _remote = [TracksServiceRemote new];
         _remote.tracksUserAgent = self.userAgent;
         _queueSendInterval = EVENT_TIMER_DEFAULT;
@@ -116,7 +118,7 @@ NSString *const USER_ID_ANON = @"anonId";
                                               username:self.username
                                                 userID:self.userID
                                              userAgent:self.userAgent
-                                              userType:self.isAnonymous ? TracksEventUserTypeAnonymous : TracksEventUserTypeWordPressCom
+                                              userType:self.isAnonymous ? TracksEventUserTypeAnonymous : TracksEventUserTypeAuthenticated
                                              eventDate:[NSDate date]
                                       customProperties:customProperties
                                       deviceProperties:[self mutableDeviceProperties]
@@ -311,6 +313,8 @@ NSString *const USER_ID_ANON = @"anonId";
 
 - (NSDictionary *)dictionaryForTracksEvent:(TracksEvent *)tracksEvent withParentCommonProperties:(NSDictionary *)parentCommonProperties
 {
+    NSParameterAssert(tracksEvent);
+    
     NSTimeInterval since1970 = tracksEvent.date.timeIntervalSince1970;
     long long since1970millis = since1970 * 1000;
     
@@ -319,10 +323,10 @@ NSString *const USER_ID_ANON = @"anonId";
     dict[TracksTimestampKey] = @(since1970millis);
     
     if (tracksEvent.userType == TracksEventUserTypeAnonymous) {
-        dict[TracksUserTypeKey] = TracksUserTypeAnonymous;
+        dict[TracksUserTypeKey] = self.anonymousUserType;
         dict[TracksUserIDKey] = tracksEvent.userID;
     } else {
-        dict[TracksUserTypeKey] = TracksUserTypeWPCOM;
+        dict[TracksUserTypeKey] = self.authenticatedUserType;
         dict[TracksUserIDKey] = tracksEvent.userID;
         dict[TracksUsernameKey] = tracksEvent.username;
     }

--- a/Automattic-Tracks-iOSTests/TracksEventServiceTests.m
+++ b/Automattic-Tracks-iOSTests/TracksEventServiceTests.m
@@ -37,7 +37,7 @@
                                                         username:@"someone"
                                                           userID:@"MOOP"
                                                        userAgent:nil
-                                                        userType:TracksEventUserTypeWordPressCom
+                                                        userType:TracksEventUserTypeAuthenticated
                                                        eventDate:[NSDate date]
                                                 customProperties:nil
                                                 deviceProperties:nil


### PR DESCRIPTION
#### Description:
This Pull Request moves over internal private strings, used to indicate the User Type, to a public property.

This will allow us to update the Username Strings for Simplenote, so that we don't have an awful namespaces collision.

@astralbodies i'd be more than happy to change / update anything you say!.

Needs Review: @astralbodies 
Thanks in advance!
