### PR TITLE
OS X Doesn't require CoreTelephony Framework

### DIFF
--- a/Automattic-Tracks-OSX.podspec
+++ b/Automattic-Tracks-OSX.podspec
@@ -10,7 +10,6 @@ Pod::Spec.new do |spec|
   spec.source_files = 'Automattic-Tracks-iOS/**/*.{h,m}'
   spec.resource_bundle = { 'DataModel' => ['Automattic-Tracks-iOS/**/*.xcdatamodeld'] }
   spec.framework    = 'CoreData'
-  spec.framework    = 'CoreTelephony'
 
   spec.dependency 'CocoaLumberjack', '2.0.0'
   spec.dependency 'Reachability', '~>3.1'


### PR DESCRIPTION
Tracks is crashing in Yosemite, since CoreTelephony isn't available there.
This wasn't picked up before, because CoreTelephony was added in El Capitan.

Needs Review: @astralbodies 
