### PR TITLE
Validates HTTP response code & content

### DIFF
--- a/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
+++ b/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		00EC19F5C9B3F78F5F50366F /* Pods_Automattic_Tracks_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EBDB237A5CBEE0EE8433798 /* Pods_Automattic_Tracks_iOS.framework */; };
+		9349E9941D41148A00DDB5BB /* TracksServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9349E9931D41148A00DDB5BB /* TracksServiceRemoteTests.swift */; };
 		93B5C7AE1CE25D40002820B3 /* Automattic-Tracks-iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B5C7AD1CE25D40002820B3 /* Automattic-Tracks-iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93B5C7B51CE25D40002820B3 /* AutomatticTracks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93B5C7AB1CE25D40002820B3 /* AutomatticTracks.framework */; };
 		93B5C7C21CE25D66002820B3 /* TracksLoggingPrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 93B5C7681CE230AD002820B3 /* TracksLoggingPrivate.m */; };
@@ -61,6 +62,8 @@
 		9333CA9D1ACB22D300ACE506 /* TracksEventCoreData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TracksEventCoreData.m; sourceTree = "<group>"; };
 		9339E70A1ADE98B800AEAB68 /* TracksConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TracksConstants.h; sourceTree = "<group>"; };
 		9339E70B1ADE98B800AEAB68 /* TracksConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TracksConstants.m; sourceTree = "<group>"; };
+		9349E9921D41148A00DDB5BB /* Automattic-Tracks-iOSTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Automattic-Tracks-iOSTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		9349E9931D41148A00DDB5BB /* TracksServiceRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TracksServiceRemoteTests.swift; sourceTree = "<group>"; };
 		937632821AC1F45600086BC6 /* TracksEventService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TracksEventService.h; sourceTree = "<group>"; };
 		937632831AC1F45600086BC6 /* TracksEventService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TracksEventService.m; sourceTree = "<group>"; };
 		937632B71AC30F8700086BC6 /* TracksEventServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TracksEventServiceTests.m; sourceTree = "<group>"; };
@@ -222,6 +225,7 @@
 		93C021291AB0A6330014096A /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				9349E9921D41148A00DDB5BB /* Automattic-Tracks-iOSTests-Bridging-Header.h */,
 				93B5C7BB1CE25D40002820B3 /* Info.plist */,
 			);
 			name = "Supporting Files";
@@ -260,6 +264,7 @@
 				937632B71AC30F8700086BC6 /* TracksEventServiceTests.m */,
 				931EE6CB1AD404D000E8711C /* TracksEventTests.m */,
 				93C0213C1AB32BFA0014096A /* TracksServiceRemoteIntegrationTests.m */,
+				9349E9931D41148A00DDB5BB /* TracksServiceRemoteTests.swift */,
 				93F595521ABA01AE00280F9E /* TracksServiceTests.m */,
 			);
 			name = Tests;
@@ -304,12 +309,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 93B5C7BC1CE25D40002820B3 /* Build configuration list for PBXNativeTarget "Automattic-Tracks-iOS" */;
 			buildPhases = (
-				03285C5F6DE693B49C7B8A5C /* 📦 Check Pods Manifest.lock */,
+				03285C5F6DE693B49C7B8A5C /* [CP] Check Pods Manifest.lock */,
 				93B5C7A61CE25D40002820B3 /* Sources */,
 				93B5C7A71CE25D40002820B3 /* Frameworks */,
 				93B5C7A81CE25D40002820B3 /* Headers */,
 				93B5C7A91CE25D40002820B3 /* Resources */,
-				6BA4389C4A42A9E74BF1D871 /* 📦 Copy Pods Resources */,
+				6BA4389C4A42A9E74BF1D871 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -324,12 +329,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 93B5C7BF1CE25D40002820B3 /* Build configuration list for PBXNativeTarget "Automattic-Tracks-iOSTests" */;
 			buildPhases = (
-				61BED20AB4A33F1EEE1C49A4 /* 📦 Check Pods Manifest.lock */,
+				61BED20AB4A33F1EEE1C49A4 /* [CP] Check Pods Manifest.lock */,
 				93B5C7B01CE25D40002820B3 /* Sources */,
 				93B5C7B11CE25D40002820B3 /* Frameworks */,
 				93B5C7B21CE25D40002820B3 /* Resources */,
-				B5AA90B9C0803BE39E1185A9 /* 📦 Embed Pods Frameworks */,
-				F129251F3ADFB63E03CDE9A2 /* 📦 Copy Pods Resources */,
+				B5AA90B9C0803BE39E1185A9 /* [CP] Embed Pods Frameworks */,
+				F129251F3ADFB63E03CDE9A2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -395,14 +400,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		03285C5F6DE693B49C7B8A5C /* 📦 Check Pods Manifest.lock */ = {
+		03285C5F6DE693B49C7B8A5C /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -410,14 +415,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		61BED20AB4A33F1EEE1C49A4 /* 📦 Check Pods Manifest.lock */ = {
+		61BED20AB4A33F1EEE1C49A4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -425,14 +430,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		6BA4389C4A42A9E74BF1D871 /* 📦 Copy Pods Resources */ = {
+		6BA4389C4A42A9E74BF1D871 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -440,14 +445,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Automattic-Tracks-iOS/Pods-Automattic-Tracks-iOS-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B5AA90B9C0803BE39E1185A9 /* 📦 Embed Pods Frameworks */ = {
+		B5AA90B9C0803BE39E1185A9 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -455,14 +460,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Automattic-Tracks-iOS-Automattic-Tracks-iOSTests/Pods-Automattic-Tracks-iOS-Automattic-Tracks-iOSTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F129251F3ADFB63E03CDE9A2 /* 📦 Copy Pods Resources */ = {
+		F129251F3ADFB63E03CDE9A2 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -500,6 +505,7 @@
 				93B5C7D91CE25D8E002820B3 /* TracksEventServiceTests.m in Sources */,
 				93B5C7DA1CE25D8E002820B3 /* TracksEventTests.m in Sources */,
 				93B5C7D81CE25D8E002820B3 /* TestTracksContextManager.m in Sources */,
+				9349E9941D41148A00DDB5BB /* TracksServiceRemoteTests.swift in Sources */,
 				93B5C7DB1CE25D8E002820B3 /* TracksServiceRemoteIntegrationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -575,6 +581,7 @@
 			baseConfigurationReference = F4CDF4E3ABD693CAED06290A /* Pods-Automattic-Tracks-iOS-Automattic-Tracks-iOSTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
@@ -584,6 +591,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.automattic.Automattic-Tracks-iOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Automattic-Tracks-iOSTests/Automattic-Tracks-iOSTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -593,6 +601,7 @@
 			baseConfigurationReference = 9D68681CFE7A89CD717A87F8 /* Pods-Automattic-Tracks-iOS-Automattic-Tracks-iOSTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
@@ -602,6 +611,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.automattic.Automattic-Tracks-iOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Automattic-Tracks-iOSTests/Automattic-Tracks-iOSTests-Bridging-Header.h";
 			};
 			name = Release;
 		};

--- a/Automattic-Tracks-iOS/TracksConstants.h
+++ b/Automattic-Tracks-iOS/TracksConstants.h
@@ -14,5 +14,6 @@ typedef NS_ENUM(NSInteger, TracksErrorCode) {
     TracksErrorCodeValidationUserPropertiesKeyFormat,
     TracksErrorCodeValidationDevicePropertiesKeyType,
     TracksErrorCodeValidationDevicePropertiesKeyFormat,
-    TracksErrorRemoteResponseInvalid
+    TracksErrorRemoteResponseInvalid,
+    TracksErrorRemoteResponseError
 };

--- a/Automattic-Tracks-iOS/TracksConstants.h
+++ b/Automattic-Tracks-iOS/TracksConstants.h
@@ -14,4 +14,5 @@ typedef NS_ENUM(NSInteger, TracksErrorCode) {
     TracksErrorCodeValidationUserPropertiesKeyFormat,
     TracksErrorCodeValidationDevicePropertiesKeyType,
     TracksErrorCodeValidationDevicePropertiesKeyFormat,
+    TracksErrorRemoteResponseInvalid
 };

--- a/Automattic-Tracks-iOS/TracksServiceRemote.h
+++ b/Automattic-Tracks-iOS/TracksServiceRemote.h
@@ -3,8 +3,10 @@
 
 @interface TracksServiceRemote : NSObject
 
-@property (nonatomic, strong) NSString *tracksUserAgent;
+@property (nonatomic, strong) NSString * _Nullable tracksUserAgent;
 
-- (void)sendBatchOfEvents:(NSArray *)events withSharedProperties:(NSDictionary *)properties completionHandler:(void (^)(NSError *error))completion;
+- (void)sendBatchOfEvents:(NSArray<TracksEvent *> * _Nonnull)events
+     withSharedProperties:(NSDictionary * _Nonnull)properties
+        completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completion;
 
 @end

--- a/Automattic-Tracks-iOS/TracksServiceRemote.m
+++ b/Automattic-Tracks-iOS/TracksServiceRemote.m
@@ -1,6 +1,24 @@
 #import "TracksServiceRemote.h"
 
+@interface TracksServiceRemote()
+
+@property (nonatomic, strong) NSURLSession *session;
+
+@end
+
 @implementation TracksServiceRemote
+
+- (NSURLSession *)session {
+    if (_session == nil) {
+        // use an ephemeral configuration because we don't need to keep any kind of permanent cache
+        NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+        // disable event memory cache
+        sessionConfiguration.URLCache = nil;
+        _session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
+    }
+
+    return _session;
+}
 
 - (void)sendBatchOfEvents:(NSArray *)events withSharedProperties:(NSDictionary *)properties completionHandler:(void (^)(NSError *error))completion
 {
@@ -16,11 +34,9 @@
     if (self.tracksUserAgent) {
         [request setValue:self.tracksUserAgent forHTTPHeaderField:@"User-Agent"];
     }
-    
-    NSURLSession *sharedSession = [NSURLSession sharedSession];
-    
+
     NSURLSessionDataTask *task;
-    task = [sharedSession dataTaskWithRequest:request
+    task = [self.session dataTaskWithRequest:request
                             completionHandler:^(NSData *data, NSURLResponse *response, NSError *completionError)
             {
                 if (completion) {

--- a/Automattic-Tracks-iOS/TracksServiceRemote.m
+++ b/Automattic-Tracks-iOS/TracksServiceRemote.m
@@ -58,7 +58,7 @@
 
                 if (data != nil) {
                     NSString *responseData = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-                    validResponseData = [responseData containsString:@"Accepted"];
+                    validResponseData = [responseData isEqualToString:@"\"Accepted\""];
                 }
 
                 if (error == nil && ![self.acceptableStatusCodes containsIndex:(NSUInteger)httpResponse.statusCode]) {

--- a/Automattic-Tracks-iOSTests/Automattic-Tracks-iOSTests-Bridging-Header.h
+++ b/Automattic-Tracks-iOSTests/Automattic-Tracks-iOSTests-Bridging-Header.h
@@ -1,0 +1,6 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "TracksServiceRemote.h"
+#import <OHHTTPStubs/OHHTTPStubs.h>

--- a/Automattic-Tracks-iOSTests/Automattic-Tracks-iOSTests-Bridging-Header.h
+++ b/Automattic-Tracks-iOSTests/Automattic-Tracks-iOSTests-Bridging-Header.h
@@ -3,4 +3,3 @@
 //
 
 #import "TracksServiceRemote.h"
-#import <OHHTTPStubs/OHHTTPStubs.h>

--- a/Automattic-Tracks-iOSTests/TracksServiceRemoteTests.swift
+++ b/Automattic-Tracks-iOSTests/TracksServiceRemoteTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+import AutomatticTracks
+import OHHTTPStubs
+
+class TracksServiceRemoteTests: XCTestCase {
+    var subject: TracksServiceRemote!
+
+    override func setUp() {
+        super.setUp()
+
+        subject = TracksServiceRemote()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+        OHHTTPStubs.removeAllStubs()
+    }
+
+    func testSendBatchOfEvents() {
+        let expectation = expectationWithDescription("Tracks events expectation")
+
+        let events = [TracksEvent]()
+
+        stub(isHost("public-api.wordpress.com")) { _ in
+            print("WHOOOOOOOOOOOOOOOO")
+            let stubData = "\"Accepted\"".dataUsingEncoding(NSUTF8StringEncoding)
+            return OHHTTPStubsResponse(data: stubData!, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+
+        subject.sendBatchOfEvents(events, withSharedProperties: [NSObject : AnyObject]()) {
+            error in
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2.0, handler: nil)
+    }
+}

--- a/Podfile
+++ b/Podfile
@@ -11,6 +11,7 @@ target 'Automattic-Tracks-iOS' do
 
   target 'Automattic-Tracks-iOSTests' do
     pod 'OCMock', '~> 3.3.1'
+    pod 'OHHTTPStubs', '~> 5.1.0'
     pod 'OHHTTPStubs/Swift', '~> 5.1.0'
   end
 end

--- a/Podfile
+++ b/Podfile
@@ -7,10 +7,11 @@ use_frameworks!
 target 'Automattic-Tracks-iOS' do
   pod 'UIDeviceIdentifier', '~> 0.4'
   pod 'CocoaLumberjack', '~> 2.2.0'
-  pod 'Reachability', '~>3.1'
+  pod 'Reachability', '~> 3.1'
 
   target 'Automattic-Tracks-iOSTests' do
-    pod 'OCMock'
+    pod 'OCMock', '~> 3.3.1'
+    pod 'OHHTTPStubs/Swift', '~> 5.1.0'
   end
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,7 +8,19 @@ PODS:
   - CocoaLumberjack/Extensions (2.2.0):
     - CocoaLumberjack/Default
   - OCMock (3.3.1)
+  - OHHTTPStubs (5.1.0):
+    - OHHTTPStubs/Default (= 5.1.0)
   - OHHTTPStubs/Core (5.1.0)
+  - OHHTTPStubs/Default (5.1.0):
+    - OHHTTPStubs/Core
+    - OHHTTPStubs/JSON
+    - OHHTTPStubs/NSURLSession
+    - OHHTTPStubs/OHPathHelpers
+  - OHHTTPStubs/JSON (5.1.0):
+    - OHHTTPStubs/Core
+  - OHHTTPStubs/NSURLSession (5.1.0):
+    - OHHTTPStubs/Core
+  - OHHTTPStubs/OHPathHelpers (5.1.0)
   - OHHTTPStubs/Swift (5.1.0):
     - OHHTTPStubs/Core
   - Reachability (3.2)
@@ -17,6 +29,7 @@ PODS:
 DEPENDENCIES:
   - CocoaLumberjack (~> 2.2.0)
   - OCMock (~> 3.3.1)
+  - OHHTTPStubs (~> 5.1.0)
   - OHHTTPStubs/Swift (~> 5.1.0)
   - Reachability (~> 3.1)
   - UIDeviceIdentifier (~> 0.4)
@@ -28,6 +41,6 @@ SPEC CHECKSUMS:
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
 
-PODFILE CHECKSUM: 651b365accd795df961b796087a670cbfb1a3cc5
+PODFILE CHECKSUM: 721e218fcc82d6b386da175d96251413f5667f51
 
 COCOAPODS: 1.0.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,22 +7,27 @@ PODS:
     - CocoaLumberjack/Core
   - CocoaLumberjack/Extensions (2.2.0):
     - CocoaLumberjack/Default
-  - OCMock (3.3)
+  - OCMock (3.3.1)
+  - OHHTTPStubs/Core (5.1.0)
+  - OHHTTPStubs/Swift (5.1.0):
+    - OHHTTPStubs/Core
   - Reachability (3.2)
   - UIDeviceIdentifier (0.5.0)
 
 DEPENDENCIES:
   - CocoaLumberjack (~> 2.2.0)
-  - OCMock
+  - OCMock (~> 3.3.1)
+  - OHHTTPStubs/Swift (~> 5.1.0)
   - Reachability (~> 3.1)
   - UIDeviceIdentifier (~> 0.4)
 
 SPEC CHECKSUMS:
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
-  OCMock: d68685bde31f69cb61d518dcb39269080c78b5ed
+  OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
+  OHHTTPStubs: 592f74439d2d72615115cf99a954237a3fbe26e5
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
 
-PODFILE CHECKSUM: 28efd03c2d3b8e9c79cb60acdace2b79f1a23706
+PODFILE CHECKSUM: 651b365accd795df961b796087a670cbfb1a3cc5
 
-COCOAPODS: 1.0.0
+COCOAPODS: 1.0.1

--- a/TracksDemo/TracksDemo.xcodeproj/project.pbxproj
+++ b/TracksDemo/TracksDemo.xcodeproj/project.pbxproj
@@ -160,12 +160,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 937632B11AC2026900086BC6 /* Build configuration list for PBXNativeTarget "TracksDemo" */;
 			buildPhases = (
+				84203C79774967ADD40081C8 /* [CP] Check Pods Manifest.lock */,
 				49351A1B96052BD7A6CB3C55 /* [CP] Check Pods Manifest.lock */,
 				9376328A1AC2026900086BC6 /* Sources */,
 				9376328B1AC2026900086BC6 /* Frameworks */,
 				9376328C1AC2026900086BC6 /* Resources */,
 				766D4FA30E63788E6D96C065 /* [CP] Embed Pods Frameworks */,
 				6E98841391E1717BD3DD5FCC /* [CP] Copy Pods Resources */,
+				EC8A6B7DD60EB9FB1F4189AF /* 📦 Embed Pods Frameworks */,
+				0C7B0A5279EC3F29F57C20A5 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -180,12 +183,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 937632B41AC2026900086BC6 /* Build configuration list for PBXNativeTarget "TracksDemoTests" */;
 			buildPhases = (
+				BA52312AC5B3E2AC3FDBCDE7 /* [CP] Check Pods Manifest.lock */,
 				7F5B746292B27D2B541DF92D /* [CP] Check Pods Manifest.lock */,
 				937632A31AC2026900086BC6 /* Sources */,
 				937632A41AC2026900086BC6 /* Frameworks */,
 				937632A51AC2026900086BC6 /* Resources */,
 				396CB34000D4F015041219BA /* [CP] Embed Pods Frameworks */,
 				05431C7752B413E46ABA5A31 /* [CP] Copy Pods Resources */,
+				705CBF13CA108A172C1EE715 /* 📦 Embed Pods Frameworks */,
+				3A9D2087D3547AE036F6FCB7 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -271,6 +277,21 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TracksDemo-TracksDemoTests/Pods-TracksDemo-TracksDemoTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		0C7B0A5279EC3F29F57C20A5 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TracksDemo/Pods-TracksDemo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		396CB34000D4F015041219BA /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -284,6 +305,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TracksDemo-TracksDemoTests/Pods-TracksDemo-TracksDemoTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3A9D2087D3547AE036F6FCB7 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TracksDemo-TracksDemoTests/Pods-TracksDemo-TracksDemoTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		49351A1B96052BD7A6CB3C55 /* [CP] Check Pods Manifest.lock */ = {
@@ -316,6 +352,21 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TracksDemo/Pods-TracksDemo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		705CBF13CA108A172C1EE715 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TracksDemo-TracksDemoTests/Pods-TracksDemo-TracksDemoTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		766D4FA30E63788E6D96C065 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -344,6 +395,51 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		84203C79774967ADD40081C8 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		BA52312AC5B3E2AC3FDBCDE7 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		EC8A6B7DD60EB9FB1F4189AF /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TracksDemo/Pods-TracksDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */


### PR DESCRIPTION
Fixes #54 

Turns out I was not verifying that the HTTP response code was valid - I had assumed NSURLSession turned a non-2xx response into an NSError. Oops.

This fixes that, adds an additional check looking for `"Success"` and unit tests to validate the changes.

Needs Review: @SergioEstevao 