### PR TITLE
Prevent tracks sending events after disabled

### DIFF
--- a/Automattic-Tracks-iOS/TracksEventPersistenceService.h
+++ b/Automattic-Tracks-iOS/TracksEventPersistenceService.h
@@ -14,6 +14,8 @@
 
 - (void)removeTracksEvents:(NSArray *)tracksEvents;
 
+- (void)clearTracksEvents;
+
 - (void)incrementRetryCountForEvents:(NSArray *)tracksEvents;
 
 @end

--- a/Automattic-Tracks-iOS/TracksEventPersistenceService.m
+++ b/Automattic-Tracks-iOS/TracksEventPersistenceService.m
@@ -93,6 +93,11 @@
 }
 
 
+- (void)clearTracksEvents
+{
+    [self removeTracksEvents:[self fetchAllTracksEvents]];
+}
+
 - (void)incrementRetryCountForEvents:(NSArray *)tracksEvents
 {
     [self.managedObjectContext performBlockAndWait:^{

--- a/Automattic-Tracks-iOS/TracksEventService.h
+++ b/Automattic-Tracks-iOS/TracksEventService.h
@@ -28,6 +28,8 @@
 
 - (NSUInteger)numberOfTracksEvents;
 
+- (void)clearTracksEvents;
+
 - (void)removeTracksEvents:(NSArray *)tracksEvents;
 
 - (void)incrementRetryCountForEvents:(NSArray *)tracksEvents;

--- a/Automattic-Tracks-iOS/TracksEventService.m
+++ b/Automattic-Tracks-iOS/TracksEventService.m
@@ -98,6 +98,12 @@
 }
 
 
+- (void)clearTracksEvents
+{
+    [self.persistenceService clearTracksEvents];
+}
+
+
 - (void)incrementRetryCountForEvents:(NSArray *)tracksEvents
 {
     [self.persistenceService incrementRetryCountForEvents:tracksEvents];

--- a/Automattic-Tracks-iOS/TracksService.h
+++ b/Automattic-Tracks-iOS/TracksService.h
@@ -33,6 +33,6 @@ extern NSString *const TrackServiceDidSendQueuedEventsNotification;
 - (void)trackEventName:(NSString *)eventName withCustomProperties:(NSDictionary *)customProperties;
 
 - (void)sendQueuedEvents;
-
+- (void)clearQueuedEvents;
 
 @end

--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -173,6 +173,10 @@ NSString *const USER_ID_ANON = @"anonId";
      ];
 }
 
+- (void)clearQueuedEvents
+{
+    [self.tracksEventService clearTracksEvents];
+}
 
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent
 {

--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -152,21 +152,22 @@ NSString *const USER_ID_ANON = @"anonId";
         NSDictionary *eventJSON = [self dictionaryForTracksEvent:tracksEvent withParentCommonProperties:commonProperties];
         [jsonEvents addObject:eventJSON];
     }
-    
+
+    __weak __typeof(self) weakSelf = self;
     [self.remote sendBatchOfEvents:jsonEvents
               withSharedProperties:commonProperties
                  completionHandler:^(NSError *error) {
                      if (error) {
                          DDLogError(@"TracksService Error while remote calling: %@", error);
-                         [self.tracksEventService incrementRetryCountForEvents:events];
+                         [weakSelf.tracksEventService incrementRetryCountForEvents:events];
                      } else {
                          DDLogVerbose(@"TracksService sendQueuedEvents completed. Sent %@ events.", @(events.count));
                          // Delete the events since they sent or errored
-                         [self.tracksEventService removeTracksEvents:events];
+                         [weakSelf.tracksEventService removeTracksEvents:events];
                      }
                          
                      // Assume no errors for now
-                     [self resetTimer];
+                     [weakSelf resetTimer];
                      
                      [[NSNotificationCenter defaultCenter] postNotificationName:TrackServiceDidSendQueuedEventsNotification object:nil];
                  }

--- a/Automattic-Tracks-iOS/TracksServiceRemote.m
+++ b/Automattic-Tracks-iOS/TracksServiceRemote.m
@@ -50,13 +50,14 @@
 
     NSURLSessionDataTask *task;
 
+    __weak __typeof(self) weakSelf = self;
     task = [self.session dataTaskWithRequest:request
                             completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error)
             {
                 NSHTTPURLResponse *httpResponse = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
 
                 // Only allow HTTP 200-299 response codes
-                if (error == nil && ![self.acceptableStatusCodes containsIndex:(NSUInteger)httpResponse.statusCode]) {
+                if (error == nil && ![weakSelf.acceptableStatusCodes containsIndex:(NSUInteger)httpResponse.statusCode]) {
                     error = [NSError errorWithDomain:TracksErrorDomain
                                                 code:TracksErrorRemoteResponseError
                                             userInfo:@{NSLocalizedDescriptionKey: @"Invalid HTTP response received from host."}];


### PR DESCRIPTION
This fixes a couple retain cycles that were preventing the Tracks service from being deallocated, so it was still sending events after the user had opted out. It also adds a safeguard to clear any queued events, in case there are more undetected leaks.

Fixes #65 

## To test

Sadly, I haven't been able to test that the leaks are fixed since Instruments keep crashing on me. You can check out the `issue/tracks-audit` branch in the WordPress app and make sure it's not sending events after analytics is disabled.