### PR TITLE
Update UIDeviceIdentifier to 1.1.4

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ inhibit_all_warnings!
 use_frameworks!
 
 target 'Automattic-Tracks-iOS' do
-  pod 'UIDeviceIdentifier', '~> 0.4'
+  pod 'UIDeviceIdentifier', '~> 1.1.4'
   pod 'CocoaLumberjack', '~> 3.4.1'
   pod 'Reachability', '~> 3.1'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - OHHTTPStubs/Swift (5.2.2):
     - OHHTTPStubs/Core
   - Reachability (3.2)
-  - UIDeviceIdentifier (0.5.0)
+  - UIDeviceIdentifier (1.1.4)
 
 DEPENDENCIES:
   - CocoaLumberjack (~> 3.4.1)
@@ -30,15 +30,23 @@ DEPENDENCIES:
   - OHHTTPStubs
   - OHHTTPStubs/Swift
   - Reachability (~> 3.1)
-  - UIDeviceIdentifier (~> 0.4)
+  - UIDeviceIdentifier (~> 1.1.4)
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - CocoaLumberjack
+    - OCMock
+    - OHHTTPStubs
+    - Reachability
+    - UIDeviceIdentifier
 
 SPEC CHECKSUMS:
   CocoaLumberjack: 2e258a064cacc8eb9a2aca318e24d02a0a7fd56d
   OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
   OHHTTPStubs: 34d9d0994e64fcf8552dbfade5ce82ada913ee31
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
+  UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
 
-PODFILE CHECKSUM: d45376a33bfa4a3828c0a18bb426f403dce786f5
+PODFILE CHECKSUM: 89cc8ff17129c102dc0e320b7ab88f636e00c284
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.5.3


### PR DESCRIPTION
This update is simple enough – the dependency `UIDeviceIdentifier` exposes an object called `UIDeviceHardware` with one method – `platformString`.

The changes to the underlying dependency merely adds different return values for the string.

~All of the tests pass locally, but having them pass in CI is waiting on #74~