### PR TITLE
Update the Travis CI Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
-install:
-- gem install cocoapods -v 1.0.0 && pod install
-osx_image: xcode7.3
+# references:
+# https://github.com/CocoaPods/pod-template/blob/master/.travis.yml
+# https://github.com/wordpress-mobile/AztecEditor-iOS/blob/develop/.travis.yml
+
+osx_image: xcode9.4
 language: objective-c
 xcode_workspace: Automattic-Tracks-iOS.xcworkspace
 xcode_scheme: Automattic-Tracks-iOS
 xcode_sdk: iphonesimulator
-
+before_install:
+ - gem install cocoapods # Since Travis is not always on latest version
+ - pod repo update --silent && pod install
+script:
+- Scripts/build.sh

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,0 +1,13 @@
+if [ ! $TRAVIS ]; then
+TRAVIS_XCODE_WORKSPACE=Automattic-Tracks-iOS.xcworkspace
+TRAVIS_XCODE_PROJECT=Automattic-Tracks-iOS.xcodeproj
+TRAVIS_XCODE_SCHEME=Automattic-Tracks-iOS
+TRAVIS_XCODE_SDK=iphonesimulator
+fi
+
+xcodebuild build test \
+-workspace "$TRAVIS_XCODE_WORKSPACE" \
+-scheme "$TRAVIS_XCODE_SCHEME" \
+-sdk "$TRAVIS_XCODE_SDK" \
+-destination "name=iPhone SE" \
+-configuration Debug | xcpretty -c && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
It now:
- Uses a more modern xcode image
- Updates Cocoapods and the spec repo _before_ trying to build (fixes issues with CP not being able to find the right versions of pods)
- Moves the build script into its own shell script to make it nice to work with

These changes are based mostly on the Aztec Editor’s TravisCI configuration, so using it should be low-risk – we already know it works great over there.

**Why are we doing this?**
https://github.com/Automattic/Automattic-Tracks-iOS/pull/72 – Update UIDeviceIdentifier to 1.1.4, is failing because of this issue