### PR TITLE
Add a check for whether the user has VoiceOver enabled

### DIFF
--- a/Automattic-Tracks-iOS/TracksDeviceInformation.h
+++ b/Automattic-Tracks-iOS/TracksDeviceInformation.h
@@ -17,5 +17,6 @@
 @property (nonatomic, readonly) NSString *currentNetworkOperator;
 @property (nonatomic, readonly) NSString *currentNetworkRadioType;
 @property (nonatomic, assign) BOOL isWiFiConnected;
+@property (nonatomic, assign) BOOL isVoiceOverEnabled;
 
 @end

--- a/Automattic-Tracks-iOS/TracksDeviceInformation.m
+++ b/Automattic-Tracks-iOS/TracksDeviceInformation.m
@@ -89,6 +89,10 @@
     return [[UIDevice currentDevice] systemVersion];
 }
 
+-(BOOL)isVoiceOverEnabled{
+    return UIAccessibilityIsVoiceOverRunning();
+}
+
 #else
 
 - (NSString *)currentNetworkOperator

--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -45,6 +45,7 @@ NSString *const DeviceInfoModelKey = @"device_info_model";
 NSString *const DeviceInfoNetworkOperatorKey = @"device_info_current_network_operator";
 NSString *const DeviceInfoRadioTypeKey = @"device_info_phone_radio_type";
 NSString *const DeviceInfoWiFiConnectedKey = @"device_info_wifi_connected";
+NSString *const DeviceInfoVoiceOverEnabledKey = @"device_info_voiceover_enabled";
 
 NSString *const TracksEventNameKey = @"_en";
 NSString *const TracksUserAgentKey = @"_via_ua";
@@ -312,7 +313,8 @@ NSString *const USER_ID_ANON = @"anonId";
     // These properties change often and should be overridden in TracksEvents if they differ
     return @{DeviceInfoNetworkOperatorKey : self.deviceInformation.currentNetworkOperator ?: @"Unknown",
              DeviceInfoRadioTypeKey : self.deviceInformation.currentNetworkRadioType ?: @"Unknown",
-             DeviceInfoWiFiConnectedKey : self.deviceInformation.isWiFiConnected ? @"YES" : @"NO"
+             DeviceInfoWiFiConnectedKey : self.deviceInformation.isWiFiConnected ? @"YES" : @"NO",
+             DeviceInfoVoiceOverEnabledKey : self.deviceInformation.isVoiceOverEnabled ? @"YES" : @"NO",
              };
 }
 


### PR DESCRIPTION
Adds support for adding the device's VoiceOver status to the Tracks event, per https://github.com/Automattic/Automattic-Tracks-iOS/issues/62.

(Fixes https://github.com/Automattic/Automattic-Tracks-iOS/issues/62)

**To Test**
There's no way to test this in the simulator – the similar doesn't allow VoiceOver to be enabled. To get around this, I've whipped up a quick testing target in https://github.com/Automattic/Automattic-Tracks-iOS/tree/add/on-device-testing-target that you can run on-device. All it does is display `DeviceInformation` keys that can't be Unit Tested.