### PR TITLE
Remove core telephony messages from logs

### DIFF
--- a/Automattic-Tracks-iOS/TracksDeviceInformation.m
+++ b/Automattic-Tracks-iOS/TracksDeviceInformation.m
@@ -43,6 +43,10 @@
 
 - (NSString *)currentNetworkOperator
 {
+    #if TARGET_OS_SIMULATOR
+        return @"Carrier (Simulator)";
+    #endif
+
     CTTelephonyNetworkInfo *netInfo = [CTTelephonyNetworkInfo new];
     CTCarrier *carrier = [netInfo subscriberCellularProvider];
 
@@ -57,6 +61,10 @@
 
 - (NSString *)currentNetworkRadioType
 {
+    #if TARGET_OS_SIMULATOR
+        return @"None (Simulator)";
+    #endif
+
     CTTelephonyNetworkInfo *netInfo = [CTTelephonyNetworkInfo new];
     NSString *type = nil;
     if ([netInfo respondsToSelector:@selector(currentRadioAccessTechnology)]) {


### PR DESCRIPTION
Currently, any application that uses Tracks will have this in the logs when running on the simulator:

> [Client] Sending selectors failed with: Error Domain=NSCocoaErrorDomain Code=4099 "The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated." UserInfo={NSDebugDescription=The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated.}

This fixes that.

**To Test**

The easiest way to see that this works is to open up one of the mobile apps that has Tracks built in (WCiOS shows it well – it happens on the first screen).

Manually applying the changes in your Pods directory, then cleaning the build folder and recompiling from scratch will show that the offending logs are removed. 

Props to @mindgraffiti for finding the source of this log entry!
