### PR TITLE
Send the status bar height for all events

### DIFF
--- a/Automattic-Tracks-iOS/TracksDeviceInformation.h
+++ b/Automattic-Tracks-iOS/TracksDeviceInformation.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 @interface TracksDeviceInformation : NSObject
 
@@ -18,5 +19,6 @@
 @property (nonatomic, readonly) NSString *currentNetworkRadioType;
 @property (nonatomic, assign) BOOL isWiFiConnected;
 @property (nonatomic, assign) BOOL isVoiceOverEnabled;
+@property (nonatomic, assign) CGFloat statusBarHeight;
 
 @end

--- a/Automattic-Tracks-iOS/TracksDeviceInformation.m
+++ b/Automattic-Tracks-iOS/TracksDeviceInformation.m
@@ -101,6 +101,10 @@
     return UIAccessibilityIsVoiceOverRunning();
 }
 
+-(CGFloat)statusBarHeight{
+    return UIApplication.sharedApplication.statusBarFrame.size.height;
+}
+
 #else
 
 - (NSString *)currentNetworkOperator

--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -46,6 +46,7 @@ NSString *const DeviceInfoNetworkOperatorKey = @"device_info_current_network_ope
 NSString *const DeviceInfoRadioTypeKey = @"device_info_phone_radio_type";
 NSString *const DeviceInfoWiFiConnectedKey = @"device_info_wifi_connected";
 NSString *const DeviceInfoVoiceOverEnabledKey = @"device_info_voiceover_enabled";
+NSString *const DeviceInfoStatusBarHeightKey = @"device_info_status_bar_height";
 
 NSString *const TracksEventNameKey = @"_en";
 NSString *const TracksUserAgentKey = @"_via_ua";
@@ -315,6 +316,7 @@ NSString *const USER_ID_ANON = @"anonId";
              DeviceInfoRadioTypeKey : self.deviceInformation.currentNetworkRadioType ?: @"Unknown",
              DeviceInfoWiFiConnectedKey : self.deviceInformation.isWiFiConnected ? @"YES" : @"NO",
              DeviceInfoVoiceOverEnabledKey : self.deviceInformation.isVoiceOverEnabled ? @"YES" : @"NO",
+             DeviceInfoStatusBarHeightKey : [NSNumber numberWithFloat:self.deviceInformation.statusBarHeight] ,
              };
 }
 


### PR DESCRIPTION
We need the data on how many users https://github.com/wordpress-mobile/WordPress-iOS/issues/823) is affecting – from there we’ll make the decision whether to mark as `wontfix`, or to redesign the launch screen.