### PR TITLE
Add is_online custom event property

### DIFF
--- a/Automattic-Tracks-iOS/TracksDeviceInformation.h
+++ b/Automattic-Tracks-iOS/TracksDeviceInformation.h
@@ -18,6 +18,10 @@
 @property (nonatomic, readonly) NSString *currentNetworkOperator;
 @property (nonatomic, readonly) NSString *currentNetworkRadioType;
 @property (nonatomic, assign) BOOL isWiFiConnected;
+/**
+ * Indicates whether the device has an Internet connection.
+ */
+@property (nonatomic, assign) BOOL isOnline;
 @property (nonatomic, assign) BOOL isAppleWatchConnected;
 @property (nonatomic, assign) BOOL isVoiceOverEnabled;
 @property (nonatomic, assign) CGFloat statusBarHeight;

--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -45,6 +45,7 @@ NSString *const DeviceInfoModelKey = @"device_info_model";
 NSString *const DeviceInfoNetworkOperatorKey = @"device_info_current_network_operator";
 NSString *const DeviceInfoRadioTypeKey = @"device_info_phone_radio_type";
 NSString *const DeviceInfoWiFiConnectedKey = @"device_info_wifi_connected";
+NSString *const DeviceInfoIsOnlineKey = @"device_info_is_online";
 NSString *const DeviceInfoAppleWatchConnectedKey = @"device_info_apple_watch_connected";
 NSString *const DeviceInfoVoiceOverEnabledKey = @"device_info_voiceover_enabled";
 NSString *const DeviceInfoStatusBarHeightKey = @"device_info_status_bar_height";
@@ -248,7 +249,8 @@ NSString *const USER_ID_ANON = @"anonId";
     }
 
     self.deviceInformation.isWiFiConnected = reachability.isReachableViaWiFi;
-    
+    self.deviceInformation.isOnline = reachability.isReachable;
+
     if (reachability.isReachable == YES && self.isHostReachable == NO) {
         DDLogVerbose(@"Tracks host is available. Enabling timer.");
         self.isHostReachable = YES;
@@ -317,6 +319,7 @@ NSString *const USER_ID_ANON = @"anonId";
     return @{DeviceInfoNetworkOperatorKey : self.deviceInformation.currentNetworkOperator ?: @"Unknown",
              DeviceInfoRadioTypeKey : self.deviceInformation.currentNetworkRadioType ?: @"Unknown",
              DeviceInfoWiFiConnectedKey : self.deviceInformation.isWiFiConnected ? @"YES" : @"NO",
+             DeviceInfoIsOnlineKey : self.deviceInformation.isOnline ? @"YES" : @"NO",
              DeviceInfoVoiceOverEnabledKey : self.deviceInformation.isVoiceOverEnabled ? @"YES" : @"NO",
              DeviceInfoAppleWatchConnectedKey : self.deviceInformation.isAppleWatchConnected ? @"YES" : @"NO",
              DeviceInfoVoiceOverEnabledKey : self.deviceInformation.isVoiceOverEnabled ? @"YES" : @"NO",


### PR DESCRIPTION
This is the first part of wordpress-mobile/WordPress-iOS#11003. 

The next step is updating the WordPress-iOS `Podfile` to use the version of this library with this change.

## Testing

This can be tested by using this library directly in WordPress-iOS.

1. Set this up as a development pod in WordPress-iOS. Replace the current `Automattic-Tracks-iOS` declaration. See [example](https://guides.cocoapods.org/using/the-podfile.html#using-the-files-from-a-folder-local-to-the-machine).
2. Run the WordPress-iOS app. Cleaning the build beforehand would be a good idea. I noticed that, sometimes, Xcode would still use the old pod version (weird).
3. Play around with the app while offline so events are logged. I'm not sure if Reachability works well in a Simulator so testing on a device is probably better.
4. Check the logged events of your WordPress account in Tracks Live View. Pick one event and validate that it has a `device_info_is_online` property. Please note that it takes a while for Tracks to display the logged events. 

We probably won't be able to test this with Tracks Trends until the next day (p4qSXL-2Yz-p2) so the Tracks Live View is what we can test for now. 