### PR TITLE
Increment podspec version to 0.3.2-beta.1

### DIFF
--- a/Automattic-Tracks-iOS/TracksConstants.m
+++ b/Automattic-Tracks-iOS/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.3";
+NSString *const TracksLibraryVersion = @"0.3.2-beta.1";


### PR DESCRIPTION
We’re skipping 0.3.1 because that tag already exists in Github.

The goal of this bump is to include the changes done in #93 in WordPress-iOS. 