### PR TITLE
Fix incorrect device_info_is_online values on first few events

### DIFF
--- a/Automattic-Tracks-iOS/TracksConstants.m
+++ b/Automattic-Tracks-iOS/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.3.3";
+NSString *const TracksLibraryVersion = @"0.3.4";

--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -78,8 +78,12 @@ NSString *const USER_ID_ANON = @"anonId";
         _contextManager = contextManager;
         _tracksEventService = [[TracksEventService alloc] initWithContextManager:contextManager];
         _deviceInformation = [TracksDeviceInformation new];
+
         _reachability = [Reachability reachabilityWithHostname:@"public-api.wordpress.com"];
         [_reachability startNotifier];
+
+        [self updateDeviceInformationFromReachability];
+
         _isHostReachable = YES;
         _timerEnabled = YES;
         _userProperties = [NSMutableDictionary new];
@@ -221,6 +225,17 @@ NSString *const USER_ID_ANON = @"anonId";
     }
 }
 
+#pragma mark - Reachability
+
+/**
+ * Update `self.deviceInformation` properties that rely on `self.reachability`.
+ */
+- (void)updateDeviceInformationFromReachability
+{
+    self.deviceInformation.isWiFiConnected = self.reachability.isReachableViaWiFi;
+    self.deviceInformation.isOnline = self.reachability.isReachable;
+}
+
 #pragma mark - Private methods
 
 - (void)didEnterBackground:(NSNotification *)notification
@@ -248,8 +263,7 @@ NSString *const USER_ID_ANON = @"anonId";
         return;
     }
 
-    self.deviceInformation.isWiFiConnected = reachability.isReachableViaWiFi;
-    self.deviceInformation.isOnline = reachability.isReachable;
+    [self updateDeviceInformationFromReachability];
 
     if (reachability.isReachable == YES && self.isHostReachable == NO) {
         DDLogVerbose(@"Tracks host is available. Enabling timer.");

--- a/Automattic-Tracks-iOS/TracksService.m
+++ b/Automattic-Tracks-iOS/TracksService.m
@@ -236,28 +236,10 @@ NSString *const USER_ID_ANON = @"anonId";
     self.deviceInformation.isOnline = self.reachability.isReachable;
 }
 
-#pragma mark - Private methods
-
-- (void)didEnterBackground:(NSNotification *)notification
-{
-    self.timerEnabled = NO;
-    [self.reachability stopNotifier];
-    [self sendQueuedEvents];
-}
-
-
-- (void)didBecomeActive:(NSNotification *)notification
-{
-    self.timerEnabled = YES;
-    [self.reachability startNotifier];
-    [self resetTimer];
-}
-
-
 - (void)reachabilityChanged:(NSNotification *)notification
 {
     Reachability *reachability = (Reachability *)notification.object;
-    
+
     // Because the containing app may already use Reachability, limit this to ours only.
     if (reachability != self.reachability) {
         return;
@@ -278,6 +260,22 @@ NSString *const USER_ID_ANON = @"anonId";
     }
 }
 
+#pragma mark - Private methods
+
+- (void)didEnterBackground:(NSNotification *)notification
+{
+    self.timerEnabled = NO;
+    [self.reachability stopNotifier];
+    [self sendQueuedEvents];
+}
+
+
+- (void)didBecomeActive:(NSNotification *)notification
+{
+    self.timerEnabled = YES;
+    [self.reachability startNotifier];
+    [self resetTimer];
+}
 
 - (void)resetTimer
 {


### PR DESCRIPTION
This is part of wordpress-mobile/WordPress-iOS#11395.

This fixes an issue where we're getting too many `NO` results for the `device_info_is_online` property. This tends to happen for events like `my_site_tab_accessed`, `login_accessed`, and `notifications_notification_details_opened`.

See paCBwp-54-p2 for more info. 

## Findings

After some investigation, I found that on `TracksService`:

1. Every time we send the events to the server, the method `mutableDeviceProperties` is called to acquire the value for custom props like `device_info_is_online` (`deviceInformation.isOnline`).
2. The `deviceInformation.isOnline` is only initialized in `-reachabilityChanged:(NSNotification *)notification`. It is `NO` by default.

The problem is, some events like `my_site_tab_accessed` are sent **before** the `isOnline` property is ever initialized. This causes those events to incorrectly report `device_info_is_online` as `NO`.

## Solution

This PR updates the `isOnline` (and additionally `isWifiConnected`) properties when the `TracksService` is initialized. When I tested it, it looks like `Reachability` reports the correct `isReachable` value during this time.

## Testing

Please test on a device if possible.

1. Check out the branch of this PR: wordpress-mobile/WordPress-iOS#11417
2. Run the WPiOS app while online. Cleaning the build beforehand would be a good idea.
3. Check the logged `my_site_tab_accessed` event in Tracks Live View. Make sure its `device_info_is_online` property is `YES`.
4. Repeat Step 2 and 3 but this time, run the app while **offline**. The `device_info_is_online` should be `NO`.

Please do some regression test the other events as well.

## Others

I believe the risk of regression is low for this so I will target WP iOS 12.2 in wordpress-mobile/WordPress-iOS#11417 when this PR is merged. 