### PR TITLE
Updates the CocoaLumberjack dependency in the podspec.

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -28,6 +28,6 @@ Pod::Spec.new do |spec|
   spec.module_name = 'AutomatticTracks'
 
   spec.ios.dependency 'UIDeviceIdentifier', '~> 1.1.4'
-  spec.dependency 'CocoaLumberjack', '~> 3.4.1'
+  spec.dependency 'CocoaLumberjack', '~> 3.5.2'
   spec.dependency 'Reachability', '~>3.1'
 end

--- a/Automattic-Tracks-iOS/TracksConstants.m
+++ b/Automattic-Tracks-iOS/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.3.4";
+NSString *const TracksLibraryVersion = @"0.3.5-beta.1";


### PR DESCRIPTION
## Description

This PR simply updates the CocoaLumberjack version in the podspec to match the one in the `Podfile`.

## Testing:

This can be testing by doing `pod install` in WPiOS's branch `issue/10294-better-error-for-invalid-url`.