### PR TITLE
Don’t track memory pressure as an event in Sentry

### DIFF
--- a/Automattic-Tracks-iOS/CrashLogging.swift
+++ b/Automattic-Tracks-iOS/CrashLogging.swift
@@ -48,9 +48,6 @@ public class CrashLogging {
             // Automatically track screen transitions
             Client.shared?.enableAutomaticBreadcrumbTracking()
 
-            // Automatically track low-memory events
-            Client.shared?.trackMemoryPressureAsEvent()
-
             // Override event serialization to append the logs, if needed
             Client.shared?.beforeSerializeEvent = sharedInstance.beforeSerializeEvent
             Client.shared?.shouldSendEvent = sharedInstance.shouldSendEvent


### PR DESCRIPTION
Pretty simple!

**To Test**
1.  Give the code a read. It's a pretty straightforward change :) 
2. Ensure that all tests are green.