### PR TITLE
Fixes some methods so they can be called from outside the main thread.

### DIFF
--- a/Automattic-Tracks-iOS/TracksConstants.m
+++ b/Automattic-Tracks-iOS/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.4.1";
+NSString *const TracksLibraryVersion = @"0.4.2-beta.1";


### PR DESCRIPTION
This PR started as a fix for https://github.com/wordpress-mobile/WordPress-iOS/issues/11664, but the truth is the crasher was already fixed here: https://github.com/Automattic/Automattic-Tracks-iOS/pull/105

The problem is that the solution proposed in the PR above will return zero whenever calling those methods from outside the main thread, which is not ideal.

## Testing:

1. Check out WPiOS branch `try/integrate-tracks-0.4.2-beta.1`
2. Install the pods (so tracks it updated to this PR).
3. Place a breakpoint here: https://github.com/wordpress-mobile/WordPress-iOS/blob/694e3bc79b3902171f721cbe16567cc3fd6b461e/WordPress/Classes/System/WordPressAppDelegate.swift#L90
4. Run the app
5. When the breakpoint hits, step over and check that the log shows appropriate values.
6. Stop the app.
7. Change the podfile so that it'll use the last available version for tracks instead of the commit that points to this PR.
8. Repeat the steps above and notice the values printed are: `Height: 0.0; orientation: Unknown`.