### PR TITLE
Bump CircleCI Orbs to 1.0.x and use CococaPods CDN Specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.35
+  # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
+  ios: wordpress-mobile/ios@1.0
 
 workflows:
   test_and_validate:
@@ -14,13 +14,17 @@ workflows:
           scheme: Automattic-Tracks-iOS
           device: iPhone XS
           ios-version: "12.2"
+          bundle-install: true
+          pod-install: true
       - ios/validate-podspec:
           name: Validate Podspec
           podspec-path: Automattic-Tracks-iOS.podspec
+          bundle-install: true
       - ios/publish-podspec:
           name: Publish pod to Trunk
           xcode-version: "10.2.0"
           podspec-path: Automattic-Tracks-iOS.podspec
+          bundle-install: true
           post-to-slack: true
           filters:
             tags:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org" do
-  gem "cocoapods", '~> 1.7.0'
+  gem "cocoapods", '~> 1.8.0'
   gem "xcpretty"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,18 +7,21 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    algoliasearch (1.27.1)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
     atomos (0.1.3)
     claide (1.0.3)
-    cocoapods (1.7.5)
+    cocoapods (1.8.4)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.7.5)
+      cocoapods-core (= 1.8.4)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.2.2, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-stats (>= 1.0.0, < 2.0)
-      cocoapods-trunk (>= 1.3.1, < 2.0)
+      cocoapods-trunk (>= 1.4.0, < 2.0)
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
       escape (~> 0.0.4)
@@ -27,9 +30,11 @@ GEM
       molinillo (~> 0.6.6)
       nap (~> 1.0)
       ruby-macho (~> 1.4)
-      xcodeproj (>= 1.10.0, < 2.0)
-    cocoapods-core (1.7.5)
+      xcodeproj (>= 1.11.1, < 2.0)
+    cocoapods-core (1.8.4)
       activesupport (>= 4.0.2, < 6)
+      algoliasearch (~> 1.0)
+      concurrent-ruby (~> 1.1)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
     cocoapods-deintegrate (1.0.4)
@@ -38,7 +43,7 @@ GEM
       nap
     cocoapods-search (1.0.0)
     cocoapods-stats (1.1.0)
-    cocoapods-trunk (1.4.0)
+    cocoapods-trunk (1.4.1)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
     cocoapods-try (1.1.0)
@@ -48,9 +53,11 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
+    httpclient (2.8.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    minitest (5.11.3)
+    json (2.2.0)
+    minitest (5.12.2)
     molinillo (0.6.6)
     nanaimo (0.2.6)
     nap (1.1.0)
@@ -60,7 +67,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    xcodeproj (1.12.0)
+    xcodeproj (1.13.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -73,7 +80,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.7.0)!
+  cocoapods (~> 1.8.0)!
   xcpretty!
 
 BUNDLED WITH

--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,5 @@
+source 'https://cdn.cocoapods.org/'
+
 inhibit_all_warnings!
 use_modular_headers!
 project 'Automattic-Tracks-iOS.xcodeproj'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -34,7 +34,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 1.1.4)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - CocoaLumberjack
     - OCMock
     - OHHTTPStubs
@@ -50,6 +50,6 @@ SPEC CHECKSUMS:
   Sentry: 26f0e6492b103e87434d1a5eea2d241a36f2c2a2
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
 
-PODFILE CHECKSUM: 83bc940e47195dca2fa3b71d2a8323930bb109e3
+PODFILE CHECKSUM: e03672e969dfa73e4f3de54010d610e1bf587a5e
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.4


### PR DESCRIPTION
Our [CircleCI Orbs repo](https://github.com/wordpress-mobile/circleci-orbs) has been stabilising and I released version 1.0.0 this week. In this PR, I am bumping the versions we use to `1.0` so that it will pick up any future 1.0.x version. This means we don't need to bump the version for any little change to our Orbs.

I have also updated the repo to use 1.8.x so that it will default to using the CocoaPods CDN specs repo.

To test:

- CircleCI is green