### PR TITLE
Disable automatic breadcrumb tracking by default

### DIFF
--- a/Automattic-Tracks-iOS/Crash Logging/CrashLogging.swift
+++ b/Automattic-Tracks-iOS/Crash Logging/CrashLogging.swift
@@ -46,11 +46,11 @@ public class CrashLogging {
             Client.shared = try Client(dsn: dataProvider.sentryDSN)
             try Client.shared?.startCrashHandler()
 
-            // Store lots of breadcrumbs to trace errors
-            Client.shared?.breadcrumbs.maxBreadcrumbs = 500
-
             // Automatically track screen transitions
-            Client.shared?.enableAutomaticBreadcrumbTracking()
+            if dataProvider.shouldEnableAutomaticBreadcrumbTracking {
+                Client.shared?.breadcrumbs.maxBreadcrumbs = 500 // Store lots of breadcrumbs to trace errors
+                Client.shared?.enableAutomaticBreadcrumbTracking()
+            }
 
             // Override event serialization to append the logs, if needed
             Client.shared?.beforeSerializeEvent = sharedInstance.beforeSerializeEvent

--- a/Automattic-Tracks-iOS/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Automattic-Tracks-iOS/Crash Logging/CrashLoggingDataProvider.swift
@@ -7,6 +7,7 @@ public protocol CrashLoggingDataProvider {
     var releaseName: String { get }
     var currentUser: TracksUser? { get }
     var additionalUserData: [String: Any] { get }
+    var shouldEnableAutomaticBreadcrumbTracking: Bool { get }
 }
 
 /// Default implementations of common protocol properties
@@ -18,5 +19,9 @@ public extension CrashLoggingDataProvider {
 
     var additionalUserData: [String: Any] {
         return [ : ]
+    }
+
+    var shouldEnableAutomaticBreadcrumbTracking: Bool {
+        return false
     }
 }


### PR DESCRIPTION
After this change, apps must explicitly opt in to breadcrumb tracking – if they don't, nothing happens.

This PR can be tested with https://github.com/wordpress-mobile/WordPress-iOS/pull/12778