### PR TITLE
Relax the version constraint on UIDeviceIdentifier

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |spec|
   spec.header_dir = 'AutomatticTracks'
   spec.module_name = 'AutomatticTracks'
 
-  spec.ios.dependency 'UIDeviceIdentifier', '~> 1.1.4'
+  spec.ios.dependency 'UIDeviceIdentifier', '~> 1'
   spec.dependency 'CocoaLumberjack', '~> 3.5.2'
   spec.dependency 'Reachability', '~>3.1'
   spec.dependency 'Sentry', '~>4'

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ abstract_target 'Automattic-Tracks' do
 
   target 'Automattic-Tracks-iOS' do
     platform :ios, '9.0'
-    pod 'UIDeviceIdentifier', '~> 1.1.4'
+    pod 'UIDeviceIdentifier', '~> 1'
   end
 
   target 'Automattic-Tracks-OSX' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - CocoaLumberjack (3.5.2):
-    - CocoaLumberjack/Core (= 3.5.2)
-  - CocoaLumberjack/Core (3.5.2)
+  - CocoaLumberjack (3.5.3):
+    - CocoaLumberjack/Core (= 3.5.3)
+  - CocoaLumberjack/Core (3.5.3)
   - OCMock (3.4.3)
   - OHHTTPStubs (8.0.0):
     - OHHTTPStubs/Default (= 8.0.0)
@@ -19,10 +19,10 @@ PODS:
   - OHHTTPStubs/Swift (8.0.0):
     - OHHTTPStubs/Default
   - Reachability (3.2)
-  - Sentry (4.3.4):
-    - Sentry/Core (= 4.3.4)
-  - Sentry/Core (4.3.4)
-  - UIDeviceIdentifier (1.1.4)
+  - Sentry (4.4.2):
+    - Sentry/Core (= 4.4.2)
+  - Sentry/Core (4.4.2)
+  - UIDeviceIdentifier (1.4.0)
 
 DEPENDENCIES:
   - CocoaLumberjack (~> 3.5.2)
@@ -31,7 +31,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift
   - Reachability (~> 3.1)
   - Sentry (~> 4)
-  - UIDeviceIdentifier (~> 1.1.4)
+  - UIDeviceIdentifier (~> 1)
 
 SPEC REPOS:
   trunk:
@@ -43,13 +43,13 @@ SPEC REPOS:
     - UIDeviceIdentifier
 
 SPEC CHECKSUMS:
-  CocoaLumberjack: 118bf4a820efc641f79fa487b75ed928dccfae23
+  CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 9cbce6364bec557cc3439aa6bb7514670d780881
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  Sentry: 26f0e6492b103e87434d1a5eea2d241a36f2c2a2
-  UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
+  Sentry: bba998b0fb157fdd6596aa73290a9d67ae47be79
+  UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
 
-PODFILE CHECKSUM: e03672e969dfa73e4f3de54010d610e1bf587a5e
+PODFILE CHECKSUM: d59f204fe9cd6d04bab3143cb435eccc76d7bbd0
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
This PR makes it easier for the host app to determine which version of the `UIDeviceIdentifier` dependency should be used – any version in the `1.0` series can be specified, and this pod won't block updates.