### PR TITLE
Fix memory layout issues with DDLogLevel

### DIFF
--- a/Automattic-Tracks-iOS/Private/TracksLoggingPrivate.h
+++ b/Automattic-Tracks-iOS/Private/TracksLoggingPrivate.h
@@ -1,2 +1,2 @@
 @import CocoaLumberjack;
-extern int ddLogLevel;
+extern DDLogLevel ddLogLevel;

--- a/Automattic-Tracks-iOS/Private/TracksLoggingPrivate.m
+++ b/Automattic-Tracks-iOS/Private/TracksLoggingPrivate.m
@@ -1,2 +1,2 @@
 #import "TracksLoggingPrivate.h"
-int ddLogLevel = DDLogLevelWarning;
+DDLogLevel ddLogLevel = DDLogLevelWarning;

--- a/Automattic-Tracks-iOS/TracksLogging.h
+++ b/Automattic-Tracks-iOS/TracksLogging.h
@@ -1,2 +1,4 @@
-int TracksGetLoggingLevel(void);
-void TracksSetLoggingLevel(int level);
+@import CocoaLumberjack;
+
+DDLogLevel TracksGetLoggingLevel(void);
+void TracksSetLoggingLevel(DDLogLevel level);

--- a/Automattic-Tracks-iOS/TracksLogging.m
+++ b/Automattic-Tracks-iOS/TracksLogging.m
@@ -1,10 +1,10 @@
 #import "TracksLogging.h"
 #import "TracksLoggingPrivate.h"
 
-int TracksGetLoggingLevel(void) {
+DDLogLevel TracksGetLoggingLevel(void) {
     return ddLogLevel;
 }
 
-void TracksSetLoggingLevel(int level) {
+void TracksSetLoggingLevel(DDLogLevel level) {
     ddLogLevel = level;
 }


### PR DESCRIPTION
Rather than using `int` as the type, we use `DDLogLevel` per https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/Documentation/DynamicLogLevels.md.

We'll need to merge https://github.com/Automattic/Automattic-Tracks-iOS/pull/117 and rebase this branch before CI will pass for this PR.