### PR TITLE
Fix Core Data warnings.

### DIFF
--- a/Automattic-Tracks-iOS/Tracks.xcdatamodeld/Tracks.xcdatamodel/contents
+++ b/Automattic-Tracks-iOS/Tracks.xcdatamodeld/Tracks.xcdatamodel/contents
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6751" systemVersion="14C1514" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15702" systemVersion="19D76" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
     <entity name="TracksEvent" representedClassName="TracksEventCoreData" syncable="YES">
-        <attribute name="customProperties" optional="YES" attributeType="Transformable" syncable="YES"/>
-        <attribute name="date" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="deviceInfo" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="customProperties" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" syncable="YES"/>
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="deviceInfo" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" syncable="YES"/>
         <attribute name="eventName" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="retryCount" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="retryCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="userAgent" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="userID" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="username" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="userProperties" optional="YES" attributeType="Transformable" syncable="YES"/>
-        <attribute name="userType" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="userProperties" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" syncable="YES"/>
+        <attribute name="userType" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="uuid" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <elements>
-        <element name="TracksEvent" positionX="-63" positionY="-18" width="128" height="210"/>
+        <element name="TracksEvent" positionX="-63" positionY="-18" width="128" height="208"/>
     </elements>
 </model>

--- a/Automattic-Tracks-iOS/TracksConstants.m
+++ b/Automattic-Tracks-iOS/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.4.3";
+NSString *const TracksLibraryVersion = @"0.4.4-beta.1";


### PR DESCRIPTION
The warning reads as:

>[error] fault: One or more models in this application are using transformable properties with transformer names that are either unset, or set to NSKeyedUnarchiveFromDataTransformerName. Please switch to using "NSSecureUnarchiveFromData" or a subclass of NSSecureUnarchiveFromDataTransformer instead. At some point, Core Data will default to using "NSSecureUnarchiveFromData" when nil is specified, and transformable properties containing classes that do not support NSSecureCoding will become unreadable.

I have followed the proposed solution, using `NSSecureUnarchiveFromData` as the transformer name.

To test:
- CI Tests should pass.
- Check out https://github.com/wordpress-mobile/WordPress-iOS/pull/13489 and follow the test steps there.