### PR TITLE
Relax dependency version constraints

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
   spec.module_name = 'AutomatticTracks'
 
   spec.ios.dependency 'UIDeviceIdentifier', '~> 1'
-  spec.dependency 'CocoaLumberjack', '~> 3.5.2'
-  spec.dependency 'Reachability', '~>3.1'
+  spec.dependency 'CocoaLumberjack', '~> 3'
+  spec.dependency 'Reachability', '~> 3'
   spec.dependency 'Sentry', '~>4'
 end

--- a/Automattic-Tracks-iOSTests/TracksServiceRemoteTests.swift
+++ b/Automattic-Tracks-iOSTests/TracksServiceRemoteTests.swift
@@ -15,7 +15,7 @@ class TracksServiceRemoteTests: XCTestCase {
         super.tearDown()
 
         subject = nil
-        OHHTTPStubs.removeAllStubs()
+        HTTPStubs.removeAllStubs()
     }
 
     func testSendBatchOfEventsAcceptedResponse() {
@@ -25,7 +25,7 @@ class TracksServiceRemoteTests: XCTestCase {
 
         stub(condition: isHost("public-api.wordpress.com")) { _ in
             let stubData = "\"Accepted\"".data(using: String.Encoding.utf8)
-            return OHHTTPStubsResponse(data: stubData!, statusCode: 200, headers: ["Content-Type": "application/json"])
+            return HTTPStubsResponse(data: stubData!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
 
         subject.sendBatch(of: events, withSharedProperties: [NSObject : AnyObject]()) {
@@ -45,7 +45,7 @@ class TracksServiceRemoteTests: XCTestCase {
 
         stub(condition: isHost("public-api.wordpress.com")) { _ in
             let stubData = "".data(using: String.Encoding.utf8)
-            return OHHTTPStubsResponse(data: stubData!, statusCode: 200, headers: ["Content-Type": "application/json"])
+            return HTTPStubsResponse(data: stubData!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
 
         subject.sendBatch(of: events, withSharedProperties: [NSObject : AnyObject]()) {
@@ -69,7 +69,7 @@ class TracksServiceRemoteTests: XCTestCase {
 
         stub(condition: isHost("public-api.wordpress.com")) { _ in
             let stubData = "".data(using: String.Encoding.utf8)
-            return OHHTTPStubsResponse(data: stubData!, statusCode: 500, headers: ["Content-Type": "application/json"])
+            return HTTPStubsResponse(data: stubData!, statusCode: 500, headers: ["Content-Type": "application/json"])
         }
 
         subject.sendBatch(of: events, withSharedProperties: [NSObject : AnyObject]()) {

--- a/Podfile
+++ b/Podfile
@@ -5,8 +5,8 @@ use_modular_headers!
 project 'Automattic-Tracks-iOS.xcodeproj'
 
 abstract_target 'Automattic-Tracks' do
-  pod 'CocoaLumberjack', '~> 3.5.2'
-  pod 'Reachability', '~> 3.1'
+  pod 'CocoaLumberjack', '~> 3'
+  pod 'Reachability', '~> 3'
   pod 'Sentry', '~> 4'
 
   target 'Automattic-Tracks-iOS' do
@@ -20,7 +20,7 @@ abstract_target 'Automattic-Tracks' do
 end
 
 abstract_target 'Automattic-Tracks-Tests' do
-  pod 'OCMock', '~> 3.4.3'
+  pod 'OCMock', '~> 3'
   pod 'OHHTTPStubs'
   pod 'OHHTTPStubs/Swift'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,27 +1,27 @@
 PODS:
-  - CocoaLumberjack (3.5.3):
-    - CocoaLumberjack/Core (= 3.5.3)
-  - CocoaLumberjack/Core (3.5.3)
-  - OCMock (3.4.3)
-  - OHHTTPStubs (8.0.0):
-    - OHHTTPStubs/Default (= 8.0.0)
-  - OHHTTPStubs/Core (8.0.0)
-  - OHHTTPStubs/Default (8.0.0):
+  - CocoaLumberjack (3.6.1):
+    - CocoaLumberjack/Core (= 3.6.1)
+  - CocoaLumberjack/Core (3.6.1)
+  - OCMock (3.6)
+  - OHHTTPStubs (9.0.0):
+    - OHHTTPStubs/Default (= 9.0.0)
+  - OHHTTPStubs/Core (9.0.0)
+  - OHHTTPStubs/Default (9.0.0):
     - OHHTTPStubs/Core
     - OHHTTPStubs/JSON
     - OHHTTPStubs/NSURLSession
     - OHHTTPStubs/OHPathHelpers
-  - OHHTTPStubs/JSON (8.0.0):
+  - OHHTTPStubs/JSON (9.0.0):
     - OHHTTPStubs/Core
-  - OHHTTPStubs/NSURLSession (8.0.0):
+  - OHHTTPStubs/NSURLSession (9.0.0):
     - OHHTTPStubs/Core
-  - OHHTTPStubs/OHPathHelpers (8.0.0)
-  - OHHTTPStubs/Swift (8.0.0):
+  - OHHTTPStubs/OHPathHelpers (9.0.0)
+  - OHHTTPStubs/Swift (9.0.0):
     - OHHTTPStubs/Default
   - Reachability (3.2)
-  - Sentry (4.4.2):
-    - Sentry/Core (= 4.4.2)
-  - Sentry/Core (4.4.2)
+  - Sentry (4.5.0):
+    - Sentry/Core (= 4.5.0)
+  - Sentry/Core (4.5.0)
   - UIDeviceIdentifier (1.4.0)
 
 DEPENDENCIES:
@@ -43,11 +43,11 @@ SPEC REPOS:
     - UIDeviceIdentifier
 
 SPEC CHECKSUMS:
-  CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
-  OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
-  OHHTTPStubs: 9cbce6364bec557cc3439aa6bb7514670d780881
+  CocoaLumberjack: b17ae15142558d08bbacf69775fa10c4abbebcc9
+  OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
+  OHHTTPStubs: cb29d2a9d09a828ecb93349a2b0c64f99e0db89f
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  Sentry: bba998b0fb157fdd6596aa73290a9d67ae47be79
+  Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
 
 PODFILE CHECKSUM: c3e39b99c53b05238f435773f204a74d20bd5ec6

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -25,11 +25,11 @@ PODS:
   - UIDeviceIdentifier (1.4.0)
 
 DEPENDENCIES:
-  - CocoaLumberjack (~> 3.5.2)
-  - OCMock (~> 3.4.3)
+  - CocoaLumberjack (~> 3)
+  - OCMock (~> 3)
   - OHHTTPStubs
   - OHHTTPStubs/Swift
-  - Reachability (~> 3.1)
+  - Reachability (~> 3)
   - Sentry (~> 4)
   - UIDeviceIdentifier (~> 1)
 
@@ -50,6 +50,6 @@ SPEC CHECKSUMS:
   Sentry: bba998b0fb157fdd6596aa73290a9d67ae47be79
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
 
-PODFILE CHECKSUM: d59f204fe9cd6d04bab3143cb435eccc76d7bbd0
+PODFILE CHECKSUM: c3e39b99c53b05238f435773f204a74d20bd5ec6
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
This PR pins the third-party dependencies for this project to their major version – this makes it far easier to update the Pods for any project that depends on this one.

While I was at it, I relaxed the constraint on `OHHTTPStubs`, which necessitated a tiny adjustment for the newer Swift version.