### PR TITLE
Add event logging upload

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors      = { 'Automattic' => 'mobile@automattic.com' }
   spec.summary      = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   spec.source       = { :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => spec.version.to_s }
-  spec.swift_version = '4.2'
+  spec.swift_version = '5.0'
 
   spec.ios.source_files = 'Automattic-Tracks-iOS/**/*.{h,m,swift}'
   spec.ios.exclude_files = 'Automattic-Tracks-OSX/Automattic_Tracks_OSX.h'

--- a/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
+++ b/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
@@ -33,8 +33,8 @@
 		F94456472429660F009A36B3 /* EventLoggingUploadQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94456442429660E009A36B3 /* EventLoggingUploadQueue.swift */; };
 		F94456482429660F009A36B3 /* EventLoggingNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94456452429660E009A36B3 /* EventLoggingNetworkService.swift */; };
 		F94456492429660F009A36B3 /* EventLoggingNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94456452429660E009A36B3 /* EventLoggingNetworkService.swift */; };
-		F944564B24296625009A36B3 /* UploadError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944564A24296625009A36B3 /* UploadError.swift */; };
-		F944564C24296625009A36B3 /* UploadError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944564A24296625009A36B3 /* UploadError.swift */; };
+		F944564B24296625009A36B3 /* EventLoggingFileUploadError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944564A24296625009A36B3 /* EventLoggingFileUploadError.swift */; };
+		F944564C24296625009A36B3 /* EventLoggingFileUploadError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944564A24296625009A36B3 /* EventLoggingFileUploadError.swift */; };
 		F94456522429666B009A36B3 /* EventLoggingUploadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944564E2429666B009A36B3 /* EventLoggingUploadManagerTests.swift */; };
 		F94456552429666B009A36B3 /* EventLoggingUploadQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94456512429666B009A36B3 /* EventLoggingUploadQueueTests.swift */; };
 		F944565724296684009A36B3 /* EventLoggingUploadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944564E2429666B009A36B3 /* EventLoggingUploadManagerTests.swift */; };
@@ -179,7 +179,7 @@
 		F9445641242965F6009A36B3 /* FileManager+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager+Extensions.swift"; sourceTree = "<group>"; };
 		F94456442429660E009A36B3 /* EventLoggingUploadQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLoggingUploadQueue.swift; sourceTree = "<group>"; };
 		F94456452429660E009A36B3 /* EventLoggingNetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLoggingNetworkService.swift; sourceTree = "<group>"; };
-		F944564A24296625009A36B3 /* UploadError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UploadError.swift; sourceTree = "<group>"; };
+		F944564A24296625009A36B3 /* EventLoggingFileUploadError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLoggingFileUploadError.swift; sourceTree = "<group>"; };
 		F944564E2429666B009A36B3 /* EventLoggingUploadManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLoggingUploadManagerTests.swift; sourceTree = "<group>"; };
 		F94456512429666B009A36B3 /* EventLoggingUploadQueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLoggingUploadQueueTests.swift; sourceTree = "<group>"; };
 		F944565A24296698009A36B3 /* Mocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mocks.swift; sourceTree = "<group>"; };
@@ -414,7 +414,7 @@
 				F9788D8D24219D66000A9BB5 /* TracksDeviceInformation.h */,
 				F9788D8324219D66000A9BB5 /* TracksDeviceInformation.m */,
 				F9788D8124219D66000A9BB5 /* LogFile.swift */,
-				F944564A24296625009A36B3 /* UploadError.swift */,
+				F944564A24296625009A36B3 /* EventLoggingFileUploadError.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -873,7 +873,7 @@
 				F9788D9C24219D66000A9BB5 /* TracksContextManager.m in Sources */,
 				F9445639242965E7009A36B3 /* EventLoggingDataSource.swift in Sources */,
 				F9788D9824219D66000A9BB5 /* TracksEventCoreData.m in Sources */,
-				F944564B24296625009A36B3 /* UploadError.swift in Sources */,
+				F944564B24296625009A36B3 /* EventLoggingFileUploadError.swift in Sources */,
 				93B5C7CB1CE25D66002820B3 /* TracksConstants.m in Sources */,
 				F944563B242965E7009A36B3 /* EventLoggingDelegate.swift in Sources */,
 				F94456462429660F009A36B3 /* EventLoggingUploadQueue.swift in Sources */,
@@ -952,7 +952,7 @@
 				F9A117BA21E69B5B002A5CD8 /* TracksLoggingPrivate.m in Sources */,
 				F944563A242965E7009A36B3 /* EventLoggingDataSource.swift in Sources */,
 				F9788D9D24219D66000A9BB5 /* TracksContextManager.m in Sources */,
-				F944564C24296625009A36B3 /* UploadError.swift in Sources */,
+				F944564C24296625009A36B3 /* EventLoggingFileUploadError.swift in Sources */,
 				F9788DAA2421A2BF000A9BB5 /* CrashLoggingDataProvider.swift in Sources */,
 				F944563C242965E7009A36B3 /* EventLoggingDelegate.swift in Sources */,
 				F94456472429660F009A36B3 /* EventLoggingUploadQueue.swift in Sources */,

--- a/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
+++ b/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		F944565C24296698009A36B3 /* Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944565A24296698009A36B3 /* Mocks.swift */; };
 		F949B1E82429681A0069FF76 /* LogEncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F949B1E72429681A0069FF76 /* LogEncryptionTests.swift */; };
 		F949B1E92429681A0069FF76 /* LogEncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F949B1E72429681A0069FF76 /* LogEncryptionTests.swift */; };
+		F94EE62C242C4C280015C18E /* LogFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94EE62B242C4C280015C18E /* LogFileTests.swift */; };
+		F94EE62D242C4C280015C18E /* LogFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94EE62B242C4C280015C18E /* LogFileTests.swift */; };
 		F970F41E21E7BBD8000664D2 /* Automattic_Tracks_OSXTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F970F41D21E7BBD8000664D2 /* Automattic_Tracks_OSXTests.m */; };
 		F970F42021E7BBD8000664D2 /* AutomatticTracks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9A117B121E69B41002A5CD8 /* AutomatticTracks.framework */; };
 		F9788D8E24219D66000A9BB5 /* LogFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9788D8124219D66000A9BB5 /* LogFile.swift */; };
@@ -184,6 +186,7 @@
 		F94456512429666B009A36B3 /* EventLoggingUploadQueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLoggingUploadQueueTests.swift; sourceTree = "<group>"; };
 		F944565A24296698009A36B3 /* Mocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mocks.swift; sourceTree = "<group>"; };
 		F949B1E72429681A0069FF76 /* LogEncryptionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogEncryptionTests.swift; sourceTree = "<group>"; };
+		F94EE62B242C4C280015C18E /* LogFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogFileTests.swift; sourceTree = "<group>"; };
 		F970F41B21E7BBD8000664D2 /* Automattic_Tracks_OSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Automattic_Tracks_OSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F970F41D21E7BBD8000664D2 /* Automattic_Tracks_OSXTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Automattic_Tracks_OSXTests.m; sourceTree = "<group>"; };
 		F970F41F21E7BBD8000664D2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -493,6 +496,7 @@
 				F949B1E72429681A0069FF76 /* LogEncryptionTests.swift */,
 				F944564E2429666B009A36B3 /* EventLoggingUploadManagerTests.swift */,
 				F94456512429666B009A36B3 /* EventLoggingUploadQueueTests.swift */,
+				F94EE62B242C4C280015C18E /* LogFileTests.swift */,
 			);
 			path = "Event Logging";
 			sourceTree = "<group>";
@@ -911,6 +915,7 @@
 				F99D033C2422D9F30091C33E /* TracksServiceRemoteIntegrationTests.m in Sources */,
 				F99D03292422D9B70091C33E /* TestTracksContextManager.m in Sources */,
 				F99D03212422D9B70091C33E /* Extensions.swift in Sources */,
+				F94EE62C242C4C280015C18E /* LogFileTests.swift in Sources */,
 				F99D033A2422D9F30091C33E /* TracksEventTests.m in Sources */,
 				F944565B24296698009A36B3 /* Mocks.swift in Sources */,
 				F99D03342422D9F30091C33E /* CrashLoggingTests.swift in Sources */,
@@ -934,6 +939,7 @@
 				F944565724296684009A36B3 /* EventLoggingUploadManagerTests.swift in Sources */,
 				F99D033F2422D9F30091C33E /* TracksServiceTests.m in Sources */,
 				F99D032A2422D9B70091C33E /* TestTracksContextManager.m in Sources */,
+				F94EE62D242C4C280015C18E /* LogFileTests.swift in Sources */,
 				F99D03222422D9B70091C33E /* Extensions.swift in Sources */,
 				F99D03482422DB800091C33E /* Tracks.xcdatamodeld in Sources */,
 				F99D03282422D9B70091C33E /* EncryptedLog.swift in Sources */,

--- a/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
+++ b/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
@@ -21,6 +21,28 @@
 		F65C4895BA44D4556D4A3693 /* Pods_Automattic_Tracks_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F12BA01F12FA7A9559D69764 /* Pods_Automattic_Tracks_iOS.framework */; };
 		F9117199240F20F0009A1EC0 /* LogEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9117198240F20F0009A1EC0 /* LogEncryptor.swift */; };
 		F911719A240F20F0009A1EC0 /* LogEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9117198240F20F0009A1EC0 /* LogEncryptor.swift */; };
+		F9445639242965E7009A36B3 /* EventLoggingDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9445635242965E7009A36B3 /* EventLoggingDataSource.swift */; };
+		F944563A242965E7009A36B3 /* EventLoggingDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9445635242965E7009A36B3 /* EventLoggingDataSource.swift */; };
+		F944563B242965E7009A36B3 /* EventLoggingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9445636242965E7009A36B3 /* EventLoggingDelegate.swift */; };
+		F944563C242965E7009A36B3 /* EventLoggingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9445636242965E7009A36B3 /* EventLoggingDelegate.swift */; };
+		F944563D242965E7009A36B3 /* EventLoggingUploadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9445637242965E7009A36B3 /* EventLoggingUploadManager.swift */; };
+		F944563E242965E7009A36B3 /* EventLoggingUploadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9445637242965E7009A36B3 /* EventLoggingUploadManager.swift */; };
+		F9445642242965F6009A36B3 /* FileManager+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9445641242965F6009A36B3 /* FileManager+Extensions.swift */; };
+		F9445643242965F6009A36B3 /* FileManager+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9445641242965F6009A36B3 /* FileManager+Extensions.swift */; };
+		F94456462429660F009A36B3 /* EventLoggingUploadQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94456442429660E009A36B3 /* EventLoggingUploadQueue.swift */; };
+		F94456472429660F009A36B3 /* EventLoggingUploadQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94456442429660E009A36B3 /* EventLoggingUploadQueue.swift */; };
+		F94456482429660F009A36B3 /* EventLoggingNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94456452429660E009A36B3 /* EventLoggingNetworkService.swift */; };
+		F94456492429660F009A36B3 /* EventLoggingNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94456452429660E009A36B3 /* EventLoggingNetworkService.swift */; };
+		F944564B24296625009A36B3 /* UploadError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944564A24296625009A36B3 /* UploadError.swift */; };
+		F944564C24296625009A36B3 /* UploadError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944564A24296625009A36B3 /* UploadError.swift */; };
+		F94456522429666B009A36B3 /* EventLoggingUploadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944564E2429666B009A36B3 /* EventLoggingUploadManagerTests.swift */; };
+		F94456552429666B009A36B3 /* EventLoggingUploadQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94456512429666B009A36B3 /* EventLoggingUploadQueueTests.swift */; };
+		F944565724296684009A36B3 /* EventLoggingUploadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944564E2429666B009A36B3 /* EventLoggingUploadManagerTests.swift */; };
+		F944565824296684009A36B3 /* EventLoggingUploadQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94456512429666B009A36B3 /* EventLoggingUploadQueueTests.swift */; };
+		F944565B24296698009A36B3 /* Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944565A24296698009A36B3 /* Mocks.swift */; };
+		F944565C24296698009A36B3 /* Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944565A24296698009A36B3 /* Mocks.swift */; };
+		F949B1E82429681A0069FF76 /* LogEncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F949B1E72429681A0069FF76 /* LogEncryptionTests.swift */; };
+		F949B1E92429681A0069FF76 /* LogEncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F949B1E72429681A0069FF76 /* LogEncryptionTests.swift */; };
 		F970F41E21E7BBD8000664D2 /* Automattic_Tracks_OSXTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F970F41D21E7BBD8000664D2 /* Automattic_Tracks_OSXTests.m */; };
 		F970F42021E7BBD8000664D2 /* AutomatticTracks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9A117B121E69B41002A5CD8 /* AutomatticTracks.framework */; };
 		F9788D8E24219D66000A9BB5 /* LogFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9788D8124219D66000A9BB5 /* LogFile.swift */; };
@@ -80,8 +102,6 @@
 		F99D03352422D9F30091C33E /* CrashLoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99D032C2422D9F30091C33E /* CrashLoggingTests.swift */; };
 		F99D03362422D9F30091C33E /* TracksEventServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F99D032D2422D9F30091C33E /* TracksEventServiceTests.m */; };
 		F99D03372422D9F30091C33E /* TracksEventServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F99D032D2422D9F30091C33E /* TracksEventServiceTests.m */; };
-		F99D03382422D9F30091C33E /* LogEncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99D032F2422D9F30091C33E /* LogEncryptionTests.swift */; };
-		F99D03392422D9F30091C33E /* LogEncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99D032F2422D9F30091C33E /* LogEncryptionTests.swift */; };
 		F99D033A2422D9F30091C33E /* TracksEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F99D03302422D9F30091C33E /* TracksEventTests.m */; };
 		F99D033B2422D9F30091C33E /* TracksEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F99D03302422D9F30091C33E /* TracksEventTests.m */; };
 		F99D033C2422D9F30091C33E /* TracksServiceRemoteIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F99D03312422D9F30091C33E /* TracksServiceRemoteIntegrationTests.m */; };
@@ -153,6 +173,17 @@
 		E1DBEA181C07071300FF2F73 /* TracksLogging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TracksLogging.h; sourceTree = "<group>"; };
 		F12BA01F12FA7A9559D69764 /* Pods_Automattic_Tracks_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Automattic_Tracks_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F9117198240F20F0009A1EC0 /* LogEncryptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogEncryptor.swift; sourceTree = "<group>"; };
+		F9445635242965E7009A36B3 /* EventLoggingDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLoggingDataSource.swift; sourceTree = "<group>"; };
+		F9445636242965E7009A36B3 /* EventLoggingDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLoggingDelegate.swift; sourceTree = "<group>"; };
+		F9445637242965E7009A36B3 /* EventLoggingUploadManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLoggingUploadManager.swift; sourceTree = "<group>"; };
+		F9445641242965F6009A36B3 /* FileManager+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager+Extensions.swift"; sourceTree = "<group>"; };
+		F94456442429660E009A36B3 /* EventLoggingUploadQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLoggingUploadQueue.swift; sourceTree = "<group>"; };
+		F94456452429660E009A36B3 /* EventLoggingNetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLoggingNetworkService.swift; sourceTree = "<group>"; };
+		F944564A24296625009A36B3 /* UploadError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UploadError.swift; sourceTree = "<group>"; };
+		F944564E2429666B009A36B3 /* EventLoggingUploadManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLoggingUploadManagerTests.swift; sourceTree = "<group>"; };
+		F94456512429666B009A36B3 /* EventLoggingUploadQueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLoggingUploadQueueTests.swift; sourceTree = "<group>"; };
+		F944565A24296698009A36B3 /* Mocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mocks.swift; sourceTree = "<group>"; };
+		F949B1E72429681A0069FF76 /* LogEncryptionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogEncryptionTests.swift; sourceTree = "<group>"; };
 		F970F41B21E7BBD8000664D2 /* Automattic_Tracks_OSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Automattic_Tracks_OSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F970F41D21E7BBD8000664D2 /* Automattic_Tracks_OSXTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Automattic_Tracks_OSXTests.m; sourceTree = "<group>"; };
 		F970F41F21E7BBD8000664D2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -186,7 +217,6 @@
 		F99D03202422D9B70091C33E /* TestTracksContextManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestTracksContextManager.m; sourceTree = "<group>"; };
 		F99D032C2422D9F30091C33E /* CrashLoggingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashLoggingTests.swift; sourceTree = "<group>"; };
 		F99D032D2422D9F30091C33E /* TracksEventServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TracksEventServiceTests.m; sourceTree = "<group>"; };
-		F99D032F2422D9F30091C33E /* LogEncryptionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogEncryptionTests.swift; sourceTree = "<group>"; };
 		F99D03302422D9F30091C33E /* TracksEventTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TracksEventTests.m; sourceTree = "<group>"; };
 		F99D03312422D9F30091C33E /* TracksServiceRemoteIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TracksServiceRemoteIntegrationTests.m; sourceTree = "<group>"; };
 		F99D03322422D9F30091C33E /* TracksServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TracksServiceTests.m; sourceTree = "<group>"; };
@@ -348,6 +378,9 @@
 		F911718B240F20B1009A1EC0 /* Event Logging */ = {
 			isa = PBXGroup;
 			children = (
+				F9445635242965E7009A36B3 /* EventLoggingDataSource.swift */,
+				F9445636242965E7009A36B3 /* EventLoggingDelegate.swift */,
+				F9445637242965E7009A36B3 /* EventLoggingUploadManager.swift */,
 				F9117198240F20F0009A1EC0 /* LogEncryptor.swift */,
 			);
 			path = "Event Logging";
@@ -357,6 +390,7 @@
 			isa = PBXGroup;
 			children = (
 				F9A0D6D82420294B00D27C01 /* FileHandle+Extensions.swift */,
+				F9445641242965F6009A36B3 /* FileManager+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -380,6 +414,7 @@
 				F9788D8D24219D66000A9BB5 /* TracksDeviceInformation.h */,
 				F9788D8324219D66000A9BB5 /* TracksDeviceInformation.m */,
 				F9788D8124219D66000A9BB5 /* LogFile.swift */,
+				F944564A24296625009A36B3 /* UploadError.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -409,6 +444,8 @@
 				F9788DCF2421B4EF000A9BB5 /* TracksServiceRemote.m */,
 				F9788DD02421B4EF000A9BB5 /* WatchSessionManager.h */,
 				F9788DD52421B4EF000A9BB5 /* WatchSessionManager.m */,
+				F94456452429660E009A36B3 /* EventLoggingNetworkService.swift */,
+				F94456442429660E009A36B3 /* EventLoggingUploadQueue.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -431,6 +468,7 @@
 				F99D031F2422D9B70091C33E /* EncryptedLog.swift */,
 				F99D031C2422D9B70091C33E /* Extensions.swift */,
 				F99D031D2422D9B70091C33E /* LogFile+TestHelpers.swift */,
+				F944565A24296698009A36B3 /* Mocks.swift */,
 			);
 			path = "Test Helpers";
 			sourceTree = "<group>";
@@ -452,7 +490,9 @@
 		F99D032E2422D9F30091C33E /* Event Logging */ = {
 			isa = PBXGroup;
 			children = (
-				F99D032F2422D9F30091C33E /* LogEncryptionTests.swift */,
+				F949B1E72429681A0069FF76 /* LogEncryptionTests.swift */,
+				F944564E2429666B009A36B3 /* EventLoggingUploadManagerTests.swift */,
+				F94456512429666B009A36B3 /* EventLoggingUploadQueueTests.swift */,
 			);
 			path = "Event Logging";
 			sourceTree = "<group>";
@@ -831,15 +871,22 @@
 				F9788D9024219D66000A9BB5 /* TracksEvent.m in Sources */,
 				F9A0D6D92420294B00D27C01 /* FileHandle+Extensions.swift in Sources */,
 				F9788D9C24219D66000A9BB5 /* TracksContextManager.m in Sources */,
+				F9445639242965E7009A36B3 /* EventLoggingDataSource.swift in Sources */,
 				F9788D9824219D66000A9BB5 /* TracksEventCoreData.m in Sources */,
+				F944564B24296625009A36B3 /* UploadError.swift in Sources */,
 				93B5C7CB1CE25D66002820B3 /* TracksConstants.m in Sources */,
+				F944563B242965E7009A36B3 /* EventLoggingDelegate.swift in Sources */,
+				F94456462429660F009A36B3 /* EventLoggingUploadQueue.swift in Sources */,
 				F9788DA92421A2BF000A9BB5 /* CrashLoggingDataProvider.swift in Sources */,
 				93B5C7C21CE25D66002820B3 /* TracksLoggingPrivate.m in Sources */,
+				F94456482429660F009A36B3 /* EventLoggingNetworkService.swift in Sources */,
 				F9788D8E24219D66000A9BB5 /* LogFile.swift in Sources */,
 				F9788D9E24219D66000A9BB5 /* TracksUser.swift in Sources */,
 				F9788DD92421B4EF000A9BB5 /* TracksService.m in Sources */,
+				F944563D242965E7009A36B3 /* EventLoggingUploadManager.swift in Sources */,
 				F99D034A2422DD100091C33E /* TestHelpers.swift in Sources */,
 				F9117199240F20F0009A1EC0 /* LogEncryptor.swift in Sources */,
+				F9445642242965F6009A36B3 /* FileManager+Extensions.swift in Sources */,
 				93B5C7CC1CE25D66002820B3 /* TracksLogging.m in Sources */,
 				F9788DE72421B4EF000A9BB5 /* WatchSessionManager.m in Sources */,
 				F9788DA72421A2BF000A9BB5 /* CrashLogging.swift in Sources */,
@@ -856,16 +903,19 @@
 			files = (
 				F99D033E2422D9F30091C33E /* TracksServiceTests.m in Sources */,
 				F99D03402422D9F30091C33E /* TracksServiceRemoteTests.swift in Sources */,
+				F94456522429666B009A36B3 /* EventLoggingUploadManagerTests.swift in Sources */,
+				F949B1E82429681A0069FF76 /* LogEncryptionTests.swift in Sources */,
 				F99D03272422D9B70091C33E /* EncryptedLog.swift in Sources */,
 				F99D03362422D9F30091C33E /* TracksEventServiceTests.m in Sources */,
 				F99D03232422D9B70091C33E /* LogFile+TestHelpers.swift in Sources */,
-				F99D03382422D9F30091C33E /* LogEncryptionTests.swift in Sources */,
 				F99D033C2422D9F30091C33E /* TracksServiceRemoteIntegrationTests.m in Sources */,
 				F99D03292422D9B70091C33E /* TestTracksContextManager.m in Sources */,
 				F99D03212422D9B70091C33E /* Extensions.swift in Sources */,
 				F99D033A2422D9F30091C33E /* TracksEventTests.m in Sources */,
+				F944565B24296698009A36B3 /* Mocks.swift in Sources */,
 				F99D03342422D9F30091C33E /* CrashLoggingTests.swift in Sources */,
 				F99D03472422DB800091C33E /* Tracks.xcdatamodeld in Sources */,
+				F94456552429666B009A36B3 /* EventLoggingUploadQueueTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -877,15 +927,18 @@
 				F99D03412422D9F30091C33E /* TracksServiceRemoteTests.swift in Sources */,
 				F99D03242422D9B70091C33E /* LogFile+TestHelpers.swift in Sources */,
 				F99D033D2422D9F30091C33E /* TracksServiceRemoteIntegrationTests.m in Sources */,
+				F944565C24296698009A36B3 /* Mocks.swift in Sources */,
+				F949B1E92429681A0069FF76 /* LogEncryptionTests.swift in Sources */,
 				F99D03372422D9F30091C33E /* TracksEventServiceTests.m in Sources */,
-				F99D03392422D9F30091C33E /* LogEncryptionTests.swift in Sources */,
 				F970F41E21E7BBD8000664D2 /* Automattic_Tracks_OSXTests.m in Sources */,
+				F944565724296684009A36B3 /* EventLoggingUploadManagerTests.swift in Sources */,
 				F99D033F2422D9F30091C33E /* TracksServiceTests.m in Sources */,
 				F99D032A2422D9B70091C33E /* TestTracksContextManager.m in Sources */,
 				F99D03222422D9B70091C33E /* Extensions.swift in Sources */,
 				F99D03482422DB800091C33E /* Tracks.xcdatamodeld in Sources */,
 				F99D03282422D9B70091C33E /* EncryptedLog.swift in Sources */,
 				F99D03352422D9F30091C33E /* CrashLoggingTests.swift in Sources */,
+				F944565824296684009A36B3 /* EventLoggingUploadQueueTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -897,15 +950,22 @@
 				F9788D9324219D66000A9BB5 /* TracksDeviceInformation.m in Sources */,
 				F9788D9124219D66000A9BB5 /* TracksEvent.m in Sources */,
 				F9A117BA21E69B5B002A5CD8 /* TracksLoggingPrivate.m in Sources */,
+				F944563A242965E7009A36B3 /* EventLoggingDataSource.swift in Sources */,
 				F9788D9D24219D66000A9BB5 /* TracksContextManager.m in Sources */,
+				F944564C24296625009A36B3 /* UploadError.swift in Sources */,
 				F9788DAA2421A2BF000A9BB5 /* CrashLoggingDataProvider.swift in Sources */,
+				F944563C242965E7009A36B3 /* EventLoggingDelegate.swift in Sources */,
+				F94456472429660F009A36B3 /* EventLoggingUploadQueue.swift in Sources */,
 				F9A0D70224216F8D00D27C01 /* FileHandle+Extensions.swift in Sources */,
 				F99D03462422DB700091C33E /* Tracks.xcdatamodeld in Sources */,
+				F94456492429660F009A36B3 /* EventLoggingNetworkService.swift in Sources */,
 				F911719A240F20F0009A1EC0 /* LogEncryptor.swift in Sources */,
 				F9788D9F24219D66000A9BB5 /* TracksUser.swift in Sources */,
 				F9788DDA2421B4EF000A9BB5 /* TracksService.m in Sources */,
+				F944563E242965E7009A36B3 /* EventLoggingUploadManager.swift in Sources */,
 				F99D034B2422DD100091C33E /* TestHelpers.swift in Sources */,
 				F9A117D221E69B84002A5CD8 /* TracksLogging.m in Sources */,
+				F9445643242965F6009A36B3 /* FileManager+Extensions.swift in Sources */,
 				F9788D9924219D66000A9BB5 /* TracksEventCoreData.m in Sources */,
 				F9788DE82421B4EF000A9BB5 /* WatchSessionManager.m in Sources */,
 				F9A117CF21E69B80002A5CD8 /* TracksConstants.m in Sources */,

--- a/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
+++ b/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
@@ -45,6 +45,10 @@
 		F949B1E92429681A0069FF76 /* LogEncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F949B1E72429681A0069FF76 /* LogEncryptionTests.swift */; };
 		F94EE62C242C4C280015C18E /* LogFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94EE62B242C4C280015C18E /* LogFileTests.swift */; };
 		F94EE62D242C4C280015C18E /* LogFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94EE62B242C4C280015C18E /* LogFileTests.swift */; };
+		F94EE632242D000E0015C18E /* EventLoggingNetworkServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94EE631242D000E0015C18E /* EventLoggingNetworkServiceTests.swift */; };
+		F94EE633242D000E0015C18E /* EventLoggingNetworkServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94EE631242D000E0015C18E /* EventLoggingNetworkServiceTests.swift */; };
+		F94EE635242D017D0015C18E /* NetworkRequestMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94EE634242D017D0015C18E /* NetworkRequestMocks.swift */; };
+		F94EE636242D017D0015C18E /* NetworkRequestMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94EE634242D017D0015C18E /* NetworkRequestMocks.swift */; };
 		F970F41E21E7BBD8000664D2 /* Automattic_Tracks_OSXTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F970F41D21E7BBD8000664D2 /* Automattic_Tracks_OSXTests.m */; };
 		F970F42021E7BBD8000664D2 /* AutomatticTracks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9A117B121E69B41002A5CD8 /* AutomatticTracks.framework */; };
 		F9788D8E24219D66000A9BB5 /* LogFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9788D8124219D66000A9BB5 /* LogFile.swift */; };
@@ -187,6 +191,8 @@
 		F944565A24296698009A36B3 /* Mocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mocks.swift; sourceTree = "<group>"; };
 		F949B1E72429681A0069FF76 /* LogEncryptionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogEncryptionTests.swift; sourceTree = "<group>"; };
 		F94EE62B242C4C280015C18E /* LogFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogFileTests.swift; sourceTree = "<group>"; };
+		F94EE631242D000E0015C18E /* EventLoggingNetworkServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLoggingNetworkServiceTests.swift; sourceTree = "<group>"; };
+		F94EE634242D017D0015C18E /* NetworkRequestMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequestMocks.swift; sourceTree = "<group>"; };
 		F970F41B21E7BBD8000664D2 /* Automattic_Tracks_OSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Automattic_Tracks_OSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F970F41D21E7BBD8000664D2 /* Automattic_Tracks_OSXTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Automattic_Tracks_OSXTests.m; sourceTree = "<group>"; };
 		F970F41F21E7BBD8000664D2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -472,6 +478,7 @@
 				F99D031C2422D9B70091C33E /* Extensions.swift */,
 				F99D031D2422D9B70091C33E /* LogFile+TestHelpers.swift */,
 				F944565A24296698009A36B3 /* Mocks.swift */,
+				F94EE634242D017D0015C18E /* NetworkRequestMocks.swift */,
 			);
 			path = "Test Helpers";
 			sourceTree = "<group>";
@@ -497,6 +504,7 @@
 				F944564E2429666B009A36B3 /* EventLoggingUploadManagerTests.swift */,
 				F94456512429666B009A36B3 /* EventLoggingUploadQueueTests.swift */,
 				F94EE62B242C4C280015C18E /* LogFileTests.swift */,
+				F94EE631242D000E0015C18E /* EventLoggingNetworkServiceTests.swift */,
 			);
 			path = "Event Logging";
 			sourceTree = "<group>";
@@ -906,10 +914,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				F99D033E2422D9F30091C33E /* TracksServiceTests.m in Sources */,
+				F94EE632242D000E0015C18E /* EventLoggingNetworkServiceTests.swift in Sources */,
 				F99D03402422D9F30091C33E /* TracksServiceRemoteTests.swift in Sources */,
 				F94456522429666B009A36B3 /* EventLoggingUploadManagerTests.swift in Sources */,
 				F949B1E82429681A0069FF76 /* LogEncryptionTests.swift in Sources */,
 				F99D03272422D9B70091C33E /* EncryptedLog.swift in Sources */,
+				F94EE635242D017D0015C18E /* NetworkRequestMocks.swift in Sources */,
 				F99D03362422D9F30091C33E /* TracksEventServiceTests.m in Sources */,
 				F99D03232422D9B70091C33E /* LogFile+TestHelpers.swift in Sources */,
 				F99D033C2422D9F30091C33E /* TracksServiceRemoteIntegrationTests.m in Sources */,
@@ -939,6 +949,8 @@
 				F944565724296684009A36B3 /* EventLoggingUploadManagerTests.swift in Sources */,
 				F99D033F2422D9F30091C33E /* TracksServiceTests.m in Sources */,
 				F99D032A2422D9B70091C33E /* TestTracksContextManager.m in Sources */,
+				F94EE633242D000E0015C18E /* EventLoggingNetworkServiceTests.swift in Sources */,
+				F94EE636242D017D0015C18E /* NetworkRequestMocks.swift in Sources */,
 				F94EE62D242C4C280015C18E /* LogFileTests.swift in Sources */,
 				F99D03222422D9B70091C33E /* Extensions.swift in Sources */,
 				F99D03482422DB800091C33E /* Tracks.xcdatamodeld in Sources */,

--- a/Automattic-Tracks-iOS/Event Logging/EventLoggingDataSource.swift
+++ b/Automattic-Tracks-iOS/Event Logging/EventLoggingDataSource.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public protocol EventLoggingDataSource {
+    /// A base-64 encoded representation of the encryption key.
+    var loggingEncryptionKey: String { get }
+
+    /// The URL to the upload endpoint for encrypted logs.
+    var logUploadURL: URL { get }
+
+    /// The path to the log file for the most recent session.
+    var previousSessionLogPath: URL? { get }
+}
+
+public extension EventLoggingDataSource {
+    // The default implementation points to the WP.com private encrypted logging API
+    var logUploadURL: URL {
+        return URL(string: "https://public-api.wordpress.com/rest/v1.1/encrypted-logging")!
+    }
+}

--- a/Automattic-Tracks-iOS/Event Logging/EventLoggingDelegate.swift
+++ b/Automattic-Tracks-iOS/Event Logging/EventLoggingDelegate.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public protocol EventLoggingDelegate {
+    /// The event logging system will call this delegate property prior to attempting to upload, giving the application a chance to determine
+    /// whether or not the upload should proceed. If this is not overridden, the default is `false`.
+    var shouldUploadLogFiles: Bool { get }
+
+    /// The event logging system will call this delegate method each time a log file starts uploading.
+    func didStartUploadingLog(_ log: LogFile)
+
+    /// The event logging system will call this delegate method if a log file upload is cancelled by the delegate.
+    func uploadCancelledByDelegate(_ log: LogFile)
+
+    /// The event logging system will call this delegate method if a log file fails to upload.
+    func uploadFailed(withError: Error, forLog: LogFile)
+
+    /// The event logging system will call this delegate method each time a log file finishes uploading.
+    func didFinishUploadingLog(_ log: LogFile)
+}
+
+/// Default implementations for EventLoggingDelegate
+public extension EventLoggingDelegate {
+
+    var shouldUploadLogFiles: Bool {
+        return false // Use a privacy-preserving default
+    }
+
+    // Empty default implementations allow the developer to only implement these if they need them
+    func didStartUploadingLog(_ log: LogFile) {}
+    func uploadCancelledByDelegate(_ log: LogFile) {}
+    func uploadFailed(withError error: Error, forLog log: LogFile) {}
+    func didFinishUploadingLog(_ log: LogFile) {}
+}

--- a/Automattic-Tracks-iOS/Event Logging/EventLoggingDelegate.swift
+++ b/Automattic-Tracks-iOS/Event Logging/EventLoggingDelegate.swift
@@ -12,9 +12,11 @@ public protocol EventLoggingDelegate {
     func uploadCancelledByDelegate(_ log: LogFile)
 
     /// The event logging system will call this delegate method if a log file fails to upload.
+    /// It may be called prior to upload starting if the file is missing, and is called prior to the `upload` callback.
     func uploadFailed(withError: Error, forLog: LogFile)
 
     /// The event logging system will call this delegate method each time a log file finishes uploading.
+    /// It is called prior to the `upload` callback.
     func didFinishUploadingLog(_ log: LogFile)
 }
 

--- a/Automattic-Tracks-iOS/Event Logging/EventLoggingUploadManager.swift
+++ b/Automattic-Tracks-iOS/Event Logging/EventLoggingUploadManager.swift
@@ -4,7 +4,7 @@ import Sodium
 
 class EventLoggingUploadManager {
 
-    private struct Constants {
+    private enum Constants {
         static let uuidHeaderKey = "log-uuid"
         static let uploadHttpMethod = "POST"
     }

--- a/Automattic-Tracks-iOS/Event Logging/EventLoggingUploadManager.swift
+++ b/Automattic-Tracks-iOS/Event Logging/EventLoggingUploadManager.swift
@@ -27,7 +27,7 @@ class EventLoggingUploadManager {
         }
 
         guard let fileContents = FileManager.default.contents(atUrl: log.url) else {
-            delegate.uploadFailed(withError: UploadError.fileMissing, forLog: log)
+            delegate.uploadFailed(withError: EventLoggingFileUploadError.fileMissing, forLog: log)
             return
         }
 

--- a/Automattic-Tracks-iOS/Event Logging/EventLoggingUploadManager.swift
+++ b/Automattic-Tracks-iOS/Event Logging/EventLoggingUploadManager.swift
@@ -9,24 +9,25 @@ class EventLoggingUploadManager {
         static let uploadHttpMethod = "POST"
     }
 
-    internal var networkService = EventLoggingNetworkService()
-
-    internal var dataSource: EventLoggingDataSource!
-    internal var delegate: EventLoggingDelegate!
+    var dataSource: EventLoggingDataSource
+    var delegate: EventLoggingDelegate
+    var networkService: EventLoggingNetworkService = EventLoggingNetworkService()
+    var fileManager: FileManager = FileManager.default
 
     typealias LogUploadCallback = (Result<Void, Error>) -> Void
 
+    init(dataSource: EventLoggingDataSource, delegate: EventLoggingDelegate) {
+        self.dataSource = dataSource
+        self.delegate = delegate
+    }
+
     func upload(_ log: LogFile, then callback: @escaping LogUploadCallback) {
-
-        precondition(delegate != nil , "You must set the Event Logging Delegate prior to attempting an upload")
-        precondition(dataSource != nil , "You must set the Event Logging Data Source prior to attempting an upload")
-
         guard delegate.shouldUploadLogFiles else {
-            delegate?.uploadCancelledByDelegate(log)
+            delegate.uploadCancelledByDelegate(log)
             return
         }
 
-        guard let fileContents = FileManager.default.contents(atUrl: log.url) else {
+        guard let fileContents = fileManager.contents(atUrl: log.url) else {
             delegate.uploadFailed(withError: EventLoggingFileUploadError.fileMissing, forLog: log)
             return
         }

--- a/Automattic-Tracks-iOS/Event Logging/EventLoggingUploadManager.swift
+++ b/Automattic-Tracks-iOS/Event Logging/EventLoggingUploadManager.swift
@@ -46,7 +46,7 @@ class EventLoggingUploadManager {
         delegate.didStartUploadingLog(log)
 
         networkService.uploadFile(request: request, fileURL: log.url) { result in
-            switch(result) {
+            switch result {
                 case .success:
                     self.delegate.didFinishUploadingLog(log)
                     callback(.success(()))

--- a/Automattic-Tracks-iOS/Event Logging/EventLoggingUploadManager.swift
+++ b/Automattic-Tracks-iOS/Event Logging/EventLoggingUploadManager.swift
@@ -1,0 +1,52 @@
+import Foundation
+import CocoaLumberjack
+import Sodium
+
+class EventLoggingUploadManager {
+
+    private struct Constants {
+        static let uuidHeaderKey = "log-uuid"
+        static let uploadHttpMethod = "POST"
+    }
+
+    internal var networkService = EventLoggingNetworkService()
+
+    internal var dataSource: EventLoggingDataSource!
+    internal var delegate: EventLoggingDelegate!
+
+    typealias LogUploadCallback = (Result<Void, Error>) -> Void
+
+    func upload(_ log: LogFile, then callback: @escaping LogUploadCallback) {
+
+        precondition(delegate != nil , "You must set the Event Logging Delegate prior to attempting an upload")
+        precondition(dataSource != nil , "You must set the Event Logging Data Source prior to attempting an upload")
+
+        guard delegate.shouldUploadLogFiles else {
+            delegate?.uploadCancelledByDelegate(log)
+            return
+        }
+
+        guard let fileContents = FileManager.default.contents(atUrl: log.url) else {
+            delegate.uploadFailed(withError: UploadError.fileMissing, forLog: log)
+            return
+        }
+
+        var request = URLRequest(url: dataSource.logUploadURL)
+        request.addValue(log.uuid, forHTTPHeaderField: Constants.uuidHeaderKey)
+        request.httpMethod = Constants.uploadHttpMethod
+        request.httpBody = fileContents
+
+        delegate.didStartUploadingLog(log)
+
+        networkService.uploadFile(request: request, fileURL: log.url) { result in
+            switch(result) {
+                case .success:
+                    self.delegate.didFinishUploadingLog(log)
+                    callback(.success(()))
+                case .failure(let error):
+                    self.delegate.uploadFailed(withError: error, forLog: log)
+                    callback(.failure(error))
+            }
+        }
+    }
+}

--- a/Automattic-Tracks-iOS/Event Logging/EventLoggingUploadManager.swift
+++ b/Automattic-Tracks-iOS/Event Logging/EventLoggingUploadManager.swift
@@ -9,16 +9,22 @@ class EventLoggingUploadManager {
         static let uploadHttpMethod = "POST"
     }
 
-    var dataSource: EventLoggingDataSource
-    var delegate: EventLoggingDelegate
-    var networkService: EventLoggingNetworkService = EventLoggingNetworkService()
-    var fileManager: FileManager = FileManager.default
+    private let dataSource: EventLoggingDataSource
+    private let delegate: EventLoggingDelegate
+    private let networkService: EventLoggingNetworkService
+    private let fileManager: FileManager
 
     typealias LogUploadCallback = (Result<Void, Error>) -> Void
 
-    init(dataSource: EventLoggingDataSource, delegate: EventLoggingDelegate) {
+    init(dataSource: EventLoggingDataSource,
+         delegate: EventLoggingDelegate,
+         networkService: EventLoggingNetworkService = EventLoggingNetworkService(),
+         fileManager: FileManager = FileManager.default
+    ) {
         self.dataSource = dataSource
         self.delegate = delegate
+        self.networkService = networkService
+        self.fileManager = fileManager
     }
 
     func upload(_ log: LogFile, then callback: @escaping LogUploadCallback) {

--- a/Automattic-Tracks-iOS/Extensions/FileManager+Extensions.swift
+++ b/Automattic-Tracks-iOS/Extensions/FileManager+Extensions.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension FileManager {
+
+    var documentsDirectory: URL {
+        let documentsDirectory = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
+        return URL(fileURLWithPath: documentsDirectory, isDirectory: true)
+    }
+
+    func contentsOfDirectory(at url: URL) throws -> [URL] {
+        return try FileManager.default.contentsOfDirectory(atPath: url.path).map { url.appendingPathComponent($0) }
+    }
+
+    func contents(atUrl url: URL) -> Data? {
+        return self.contents(atPath: url.path)
+    }
+
+    func fileExistsAtURL(_ url: URL) -> Bool {
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    func directoryExistsAtURL(_ url: URL) -> Bool {
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir)
+        return exists && isDir.boolValue
+    }
+}

--- a/Automattic-Tracks-iOS/Extensions/FileManager+Extensions.swift
+++ b/Automattic-Tracks-iOS/Extensions/FileManager+Extensions.swift
@@ -8,7 +8,7 @@ extension FileManager {
     }
 
     func contentsOfDirectory(at url: URL) throws -> [URL] {
-        return try FileManager.default.contentsOfDirectory(atPath: url.path).map { url.appendingPathComponent($0) }
+        return try self.contentsOfDirectory(atPath: url.path).map { url.appendingPathComponent($0) }
     }
 
     func contents(atUrl url: URL) -> Data? {
@@ -16,12 +16,12 @@ extension FileManager {
     }
 
     func fileExistsAtURL(_ url: URL) -> Bool {
-        return FileManager.default.fileExists(atPath: url.path)
+        return self.fileExists(atPath: url.path)
     }
 
     func directoryExistsAtURL(_ url: URL) -> Bool {
         var isDir: ObjCBool = false
-        let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir)
+        let exists = self.fileExists(atPath: url.path, isDirectory: &isDir)
         return exists && isDir.boolValue
     }
 }

--- a/Automattic-Tracks-iOS/Model/EventLoggingFileUploadError.swift
+++ b/Automattic-Tracks-iOS/Model/EventLoggingFileUploadError.swift
@@ -7,7 +7,9 @@ public enum EventLoggingFileUploadError: Error, LocalizedError {
     public var errorDescription: String? {
         switch self {
             case .httpError(let message): return message
-            case .fileMissing: return "File not found"
+            case .fileMissing: return NSLocalizedString(
+                "File not found", comment: "A message indicating that a file queued for upload could not be found"
+            )
         }
     }
 }

--- a/Automattic-Tracks-iOS/Model/EventLoggingFileUploadError.swift
+++ b/Automattic-Tracks-iOS/Model/EventLoggingFileUploadError.swift
@@ -4,7 +4,7 @@ public enum EventLoggingFileUploadError: Error, LocalizedError {
     case httpError(String)
     case fileMissing
 
-    public var errorDescription: String?{
+    public var errorDescription: String? {
         switch self {
             case .httpError(let message): return message
             case .fileMissing: return "File not found"

--- a/Automattic-Tracks-iOS/Model/EventLoggingFileUploadError.swift
+++ b/Automattic-Tracks-iOS/Model/EventLoggingFileUploadError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum UploadError: Error, LocalizedError {
+public enum EventLoggingFileUploadError: Error, LocalizedError {
     case httpError(String)
     case fileMissing
 

--- a/Automattic-Tracks-iOS/Model/LogFile.swift
+++ b/Automattic-Tracks-iOS/Model/LogFile.swift
@@ -8,4 +8,12 @@ public struct LogFile {
         self.url = url
         self.uuid = uuid
     }
+
+    var fileName: String {
+        return uuid
+    }
+
+    static func fromExistingFile(at url: URL) -> LogFile {
+        return LogFile(url: url, uuid: url.lastPathComponent)
+    }
 }

--- a/Automattic-Tracks-iOS/Model/UploadError.swift
+++ b/Automattic-Tracks-iOS/Model/UploadError.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public enum UploadError: Error, LocalizedError {
+    case httpError(String)
+    case fileMissing
+
+    public var errorDescription: String?{
+        switch self {
+            case .httpError(let message): return message
+            case .fileMissing: return "File not found"
+        }
+    }
+}

--- a/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
+++ b/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+typealias NetworkResultCallback = (Result<Data?, Error>) -> Void
+
+open class EventLoggingNetworkService {
+
+    func uploadFile(request: URLRequest, fileURL: URL, completion: @escaping NetworkResultCallback) {
+        URLSession.shared
+            .uploadTask(with: request, fromFile: fileURL, completionHandler: { data, response, error in
+
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            /// The `response` should *always* be an HTTPURLResponse, but we'll be defensive anyway
+            guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {
+                completion(.success(data))
+                return
+            }
+
+            /// Generate a reasonable error message based on the HTTP status
+            if !(200 ... 299).contains(statusCode) {
+                let errorMessage = HTTPURLResponse.localizedString(forStatusCode: statusCode)
+                completion(.failure(UploadError.httpError(errorMessage)))
+                return
+            }
+
+            completion(.success(data))
+        }).resume()
+    }
+}

--- a/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
+++ b/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
@@ -4,9 +4,15 @@ typealias NetworkResultCallback = (Result<Data?, Error>) -> Void
 
 open class EventLoggingNetworkService {
 
+
+    private let urlSession: URLSession
+
+    init(urlSession: URLSession = URLSession.shared) {
+        self.urlSession = urlSession
+    }
+
     func uploadFile(request: URLRequest, fileURL: URL, completion: @escaping NetworkResultCallback) {
-        URLSession.shared
-            .uploadTask(with: request, fromFile: fileURL, completionHandler: { data, response, error in
+        urlSession.uploadTask(with: request, fromFile: fileURL, completionHandler: { data, response, error in
 
             if let error = error {
                 completion(.failure(error))

--- a/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
+++ b/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
@@ -13,11 +13,8 @@ open class EventLoggingNetworkService {
                 return
             }
 
-            /// The `response` should *always* be an HTTPURLResponse, but we'll be defensive anyway
-            guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {
-                completion(.success(data))
-                return
-            }
+            /// The `response` should *always* be an HTTPURLResponse. Crash if notl
+            let statusCode = (response as! HTTPURLResponse).statusCode
 
             /// Generate a reasonable error message based on the HTTP status
             if !(200 ... 299).contains(statusCode) {

--- a/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
+++ b/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
@@ -1,9 +1,8 @@
 import Foundation
 
-typealias NetworkResultCallback = (Result<Data?, Error>) -> Void
-
 open class EventLoggingNetworkService {
 
+    typealias ResultCallback = (Result<Data?, Error>) -> Void
 
     private let urlSession: URLSession
 
@@ -11,7 +10,7 @@ open class EventLoggingNetworkService {
         self.urlSession = urlSession
     }
 
-    func uploadFile(request: URLRequest, fileURL: URL, completion: @escaping NetworkResultCallback) {
+    func uploadFile(request: URLRequest, fileURL: URL, completion: @escaping ResultCallback) {
         urlSession.uploadTask(with: request, fromFile: fileURL, completionHandler: { data, response, error in
 
             if let error = error {

--- a/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
+++ b/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-open class EventLoggingNetworkService {
+class EventLoggingNetworkService {
 
     typealias ResultCallback = (Result<Data?, Error>) -> Void
 

--- a/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
+++ b/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
@@ -18,7 +18,8 @@ class EventLoggingNetworkService {
                 return
             }
 
-            /// The `response` should *always* be an HTTPURLResponse. Crash if notl
+            /// The `response` should *always* be an HTTPURLResponse.
+            /// Fail fast by force-unwrapping – this will cause a crash and will bring the issue to our attention if something has changed.
             let statusCode = (response as! HTTPURLResponse).statusCode
 
             /// Generate a reasonable error message based on the HTTP status

--- a/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
+++ b/Automattic-Tracks-iOS/Services/EventLoggingNetworkService.swift
@@ -24,7 +24,7 @@ open class EventLoggingNetworkService {
             /// Generate a reasonable error message based on the HTTP status
             if !(200 ... 299).contains(statusCode) {
                 let errorMessage = HTTPURLResponse.localizedString(forStatusCode: statusCode)
-                completion(.failure(UploadError.httpError(errorMessage)))
+                completion(.failure(EventLoggingFileUploadError.httpError(errorMessage)))
                 return
             }
 

--- a/Automattic-Tracks-iOS/Services/EventLoggingUploadQueue.swift
+++ b/Automattic-Tracks-iOS/Services/EventLoggingUploadQueue.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-open class EventLoggingUploadQueue {
+class EventLoggingUploadQueue {
 
     private let fileManager: FileManager
     var storageDirectory: URL

--- a/Automattic-Tracks-iOS/Services/EventLoggingUploadQueue.swift
+++ b/Automattic-Tracks-iOS/Services/EventLoggingUploadQueue.swift
@@ -21,14 +21,14 @@ open class EventLoggingUploadQueue {
     }
 
     func add(_ log: LogFile) throws {
-        try ensureStorageDirectoryExists()
+        try createStorageDirectoryIfNeeded()
         try fileManager.copyItem(at: log.url, to: storageURL(forLog: log))
     }
 
     func remove(_ log: LogFile) throws {
         let url = storageURL(forLog: log)
         if fileManager.fileExistsAtURL(url) {
-            try fileManager.removeItem(at: storageURL(forLog: log))
+            try fileManager.removeItem(at: url)
         }
     }
 
@@ -36,7 +36,7 @@ open class EventLoggingUploadQueue {
         return storageDirectory.appendingPathComponent(log.uuid)
     }
 
-    func ensureStorageDirectoryExists() throws {
+    func createStorageDirectoryIfNeeded() throws {
         if !fileManager.directoryExistsAtURL(storageDirectory) {
             try fileManager.createDirectory(at: storageDirectory, withIntermediateDirectories: true, attributes: nil)
         }

--- a/Automattic-Tracks-iOS/Services/EventLoggingUploadQueue.swift
+++ b/Automattic-Tracks-iOS/Services/EventLoggingUploadQueue.swift
@@ -17,23 +17,19 @@ open class EventLoggingUploadQueue {
             return nil
         }
 
-        return LogFile(url: url, uuid: url.lastPathComponent)
+        return LogFile.fromExistingFile(at: url)
     }
 
     func add(_ log: LogFile) throws {
         try createStorageDirectoryIfNeeded()
-        try fileManager.copyItem(at: log.url, to: storageURL(forLog: log))
+        try fileManager.copyItem(at: log.url, to: storageDirectory.appendingPathComponent(log.fileName))
     }
 
     func remove(_ log: LogFile) throws {
-        let url = storageURL(forLog: log)
+        let url = storageDirectory.appendingPathComponent(log.fileName)
         if fileManager.fileExistsAtURL(url) {
             try fileManager.removeItem(at: url)
         }
-    }
-
-    func storageURL(forLog log: LogFile) -> URL {
-        return storageDirectory.appendingPathComponent(log.uuid)
     }
 
     func createStorageDirectoryIfNeeded() throws {

--- a/Automattic-Tracks-iOS/Services/EventLoggingUploadQueue.swift
+++ b/Automattic-Tracks-iOS/Services/EventLoggingUploadQueue.swift
@@ -2,11 +2,17 @@ import Foundation
 
 open class EventLoggingUploadQueue {
 
-    private let fileManager = FileManager.default
+    private let fileManager: FileManager
+    var storageDirectory: URL
+
+    init(storageDirectory: URL? = nil, fileManager: FileManager = FileManager.default) {
+        let defaultStorageDirectory = fileManager.documentsDirectory.appendingPathComponent("log-upload-queue")
+        self.storageDirectory = storageDirectory ?? defaultStorageDirectory
+        self.fileManager = fileManager
+    }
 
     /// The log file on top of the queue
     var first: LogFile? {
-
         guard let url = try? fileManager.contentsOfDirectory(at: storageDirectory).first else {
             return nil
         }
@@ -26,13 +32,8 @@ open class EventLoggingUploadQueue {
         }
     }
 
-    var storageDirectory: URL {
-        return fileManager.documentsDirectory.appendingPathComponent("log-upload-queue")
-    }
-
     func storageURL(forLog log: LogFile) -> URL {
-        let newURL = storageDirectory.appendingPathComponent(log.uuid)
-        return newURL
+        return storageDirectory.appendingPathComponent(log.uuid)
     }
 
     func ensureStorageDirectoryExists() throws {

--- a/Automattic-Tracks-iOS/Services/EventLoggingUploadQueue.swift
+++ b/Automattic-Tracks-iOS/Services/EventLoggingUploadQueue.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+open class EventLoggingUploadQueue {
+
+    private let fileManager = FileManager.default
+
+    /// The log file on top of the queue
+    var first: LogFile? {
+
+        guard let url = try? fileManager.contentsOfDirectory(at: storageDirectory).first else {
+            return nil
+        }
+
+        return LogFile(url: url, uuid: url.lastPathComponent)
+    }
+
+    func add(_ log: LogFile) throws {
+        try ensureStorageDirectoryExists()
+        try fileManager.copyItem(at: log.url, to: storageURL(forLog: log))
+    }
+
+    func remove(_ log: LogFile) throws {
+        let url = storageURL(forLog: log)
+        if fileManager.fileExistsAtURL(url) {
+            try fileManager.removeItem(at: storageURL(forLog: log))
+        }
+    }
+
+    var storageDirectory: URL {
+        return fileManager.documentsDirectory.appendingPathComponent("log-upload-queue")
+    }
+
+    func storageURL(forLog log: LogFile) -> URL {
+        let newURL = storageDirectory.appendingPathComponent(log.uuid)
+        return newURL
+    }
+
+    func ensureStorageDirectoryExists() throws {
+        if !fileManager.directoryExistsAtURL(storageDirectory) {
+            try fileManager.createDirectory(at: storageDirectory, withIntermediateDirectories: true, attributes: nil)
+        }
+    }
+}

--- a/Automattic-Tracks-iOSTests/Test Helpers/Extensions.swift
+++ b/Automattic-Tracks-iOSTests/Test Helpers/Extensions.swift
@@ -29,7 +29,7 @@ extension FileManager {
 }
 
 extension XCTestCase {
-    func async_test(timeout: TimeInterval, _ block: (XCTestExpectation) -> ()) {
+    func waitForExpectation(timeout: TimeInterval, _ block: (XCTestExpectation) -> ()) {
         let exp = XCTestExpectation()
         block(exp)
         wait(for: [exp], timeout: timeout)

--- a/Automattic-Tracks-iOSTests/Test Helpers/Extensions.swift
+++ b/Automattic-Tracks-iOSTests/Test Helpers/Extensions.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Sodium
+import XCTest
 
 extension String {
     static func randomString(length: Int) -> String {
@@ -24,5 +25,13 @@ extension FileManager {
         let fileURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(name)
         self.createFile(atPath: fileURL.path, contents: contents?.data(using: .utf8), attributes: nil)
         return fileURL
+    }
+}
+
+extension XCTestCase {
+    func async_test(timeout: TimeInterval, _ block: (XCTestExpectation) -> ()) {
+        let exp = XCTestExpectation()
+        block(exp)
+        wait(for: [exp], timeout: timeout)
     }
 }

--- a/Automattic-Tracks-iOSTests/Test Helpers/LogFile+TestHelpers.swift
+++ b/Automattic-Tracks-iOSTests/Test Helpers/LogFile+TestHelpers.swift
@@ -13,4 +13,8 @@ extension LogFile {
     static func containingRandomString(length: Int = 128) -> LogFile {
         return LogFile(containing: String.randomString(length: length))
     }
+
+    static func withInvalidPath() -> LogFile {
+        return LogFile(url: URL(fileURLWithPath: "invalid"))
+    }
 }

--- a/Automattic-Tracks-iOSTests/Test Helpers/Mocks.swift
+++ b/Automattic-Tracks-iOSTests/Test Helpers/Mocks.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Sodium
+@testable import AutomatticTracks
+
+typealias LogFileCallback = (LogFile) -> ()
+typealias ErrorWithLogFileCallback = (Error, LogFile) -> ()
+
+enum MockError: Error {
+    case generic
+}
+
+class MockEventLoggingDataSource: EventLoggingDataSource {
+
+    var loggingEncryptionKey: String = "foo"
+    var previousSessionLogPath: URL? = nil
+
+    /// Overrides for logUploadURL
+    var _logUploadURL: URL = URL(string: "example.com")!
+    var logUploadURL: URL {
+        return _logUploadURL
+    }
+
+    func setLogUploadUrl(_ url: URL) {
+        self._logUploadURL = url
+    }
+
+    func withEncryptionKeys() -> Self {
+        let keyPair = Sodium().box.keyPair()!
+        loggingEncryptionKey = Data(keyPair.publicKey).base64EncodedString()
+        return self
+    }
+}
+
+class MockEventLoggingDelegate: EventLoggingDelegate {
+
+    var didStartUploadingTriggered = false
+    var didStartUploadingCallback: LogFileCallback?
+
+    func didStartUploadingLog(_ log: LogFile) {
+        didStartUploadingTriggered = true
+        didStartUploadingCallback?(log)
+    }
+
+    var didFinishUploadingTriggered = false
+    var didFinishUploadingCallback: LogFileCallback?
+
+    func didFinishUploadingLog(_ log: LogFile) {
+        didFinishUploadingTriggered = true
+        didFinishUploadingCallback?(log)
+    }
+
+    var uploadCancelledByDelegateTriggered = false
+    var uploadCancelledByDelegateCallback: LogFileCallback?
+    
+    func uploadCancelledByDelegate(_ log: LogFile) {
+        uploadCancelledByDelegateTriggered = true
+        uploadCancelledByDelegateCallback?(log)
+    }
+
+    var uploadFailedTriggered = false
+    var uploadFailedCallback: ErrorWithLogFileCallback?
+
+    func uploadFailed(withError error: Error, forLog log: LogFile) {
+        uploadFailedTriggered = true
+        uploadFailedCallback?(error, log)
+    }
+
+    func setShouldUploadLogFiles(_ newValue: Bool) {
+        _shouldUploadLogFiles = newValue
+    }
+
+    private var _shouldUploadLogFiles: Bool = true
+    var shouldUploadLogFiles: Bool {
+        return _shouldUploadLogFiles
+    }
+}
+
+class MockEventLoggingNetworkService: EventLoggingNetworkService {
+    var shouldSucceed = true
+
+    override func uploadFile(request: URLRequest, fileURL: URL, completion: @escaping NetworkResultCallback) {
+        shouldSucceed ? completion(.success(Data())) : completion(.failure(MockError.generic))
+    }
+}
+
+class MockEventLoggingUploadQueue: EventLoggingUploadQueue {
+
+    typealias LogFileCallback = (LogFile) -> ()
+
+    var queue = [LogFile]()
+
+    var addCallback: LogFileCallback?
+    override func add(_ log: LogFile) {
+        self.addCallback?(log)
+        self.queue.append(log)
+    }
+
+    var removeCallback: LogFileCallback?
+    override func remove(_ log: LogFile) {
+        self.removeCallback?(log)
+        self.queue.removeAll(where: { $0.uuid == log.uuid })
+    }
+
+    override var first: LogFile? {
+        return self.queue.first
+    }
+}

--- a/Automattic-Tracks-iOSTests/Test Helpers/Mocks.swift
+++ b/Automattic-Tracks-iOSTests/Test Helpers/Mocks.swift
@@ -78,7 +78,7 @@ class MockEventLoggingDelegate: EventLoggingDelegate {
 class MockEventLoggingNetworkService: EventLoggingNetworkService {
     var shouldSucceed = true
 
-    override func uploadFile(request: URLRequest, fileURL: URL, completion: @escaping NetworkResultCallback) {
+    override func uploadFile(request: URLRequest, fileURL: URL, completion: @escaping EventLoggingNetworkService.ResultCallback) {
         shouldSucceed ? completion(.success(Data())) : completion(.failure(MockError.generic))
     }
 }

--- a/Automattic-Tracks-iOSTests/Test Helpers/Mocks.swift
+++ b/Automattic-Tracks-iOSTests/Test Helpers/Mocks.swift
@@ -51,7 +51,7 @@ class MockEventLoggingDelegate: EventLoggingDelegate {
 
     var uploadCancelledByDelegateTriggered = false
     var uploadCancelledByDelegateCallback: LogFileCallback?
-    
+
     func uploadCancelledByDelegate(_ log: LogFile) {
         uploadCancelledByDelegateTriggered = true
         uploadCancelledByDelegateCallback?(log)

--- a/Automattic-Tracks-iOSTests/Test Helpers/NetworkRequestMocks.swift
+++ b/Automattic-Tracks-iOSTests/Test Helpers/NetworkRequestMocks.swift
@@ -1,0 +1,9 @@
+import Foundation
+import OHHTTPStubs
+
+func stubResponse(domain: String, status: String, statusCode: Int32 = 200) {
+    stub(condition: isHost(domain)) { _ in
+        let stubData = "{status: \"\(status)\"}".data(using: .utf8)!
+        return HTTPStubsResponse(data: stubData, statusCode: statusCode, headers: nil)
+    }
+}

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingNetworkServiceTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingNetworkServiceTests.swift
@@ -23,7 +23,7 @@ class EventLoggingNetworkServiceTests: XCTestCase {
         let logFile = LogFile.containingRandomString()
         let req = URLRequest(url: URL(string: "invalid://location")!)
 
-        async_test(timeout: 1.0) { exp in
+        waitForExpectation(timeout: 1.0) { exp in
             service.uploadFile(request: req, fileURL: logFile.url) { result in
                 switch result {
                     case .success(_): XCTFail("This request should not be successful – the url is invalid")
@@ -41,7 +41,7 @@ class EventLoggingNetworkServiceTests: XCTestCase {
         let logFile = LogFile.containingRandomString()
         let req = URLRequest(url: testURL())
 
-        async_test(timeout: 1.0) { exp in
+        waitForExpectation(timeout: 1.0) { exp in
             service.uploadFile(request: req, fileURL: logFile.url) { result in
                 switch result {
                     case .success(_): XCTFail("This request is not successful – the server is returning an error code")
@@ -59,8 +59,8 @@ class EventLoggingNetworkServiceTests: XCTestCase {
 
         let logFile = LogFile.containingRandomString()
         let req = URLRequest(url: testURL())
-
-        async_test(timeout: 1.0) { exp in
+        
+        waitForExpectation(timeout: 1.0) { exp in
             service.uploadFile(request: req, fileURL: logFile.url) { result in
                 switch result {
                     case .success(let response):

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingNetworkServiceTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingNetworkServiceTests.swift
@@ -26,7 +26,7 @@ class EventLoggingNetworkServiceTests: XCTestCase {
         waitForExpectation(timeout: 1.0) { exp in
             service.uploadFile(request: req, fileURL: logFile.url) { result in
                 switch result {
-                    case .success(_): XCTFail("This request should not be successful – the url is invalid")
+                    case .success: XCTFail("This request should not be successful – the url is invalid")
                     case .failure(let error): XCTAssertNotNil(error)
                 }
 
@@ -44,7 +44,7 @@ class EventLoggingNetworkServiceTests: XCTestCase {
         waitForExpectation(timeout: 1.0) { exp in
             service.uploadFile(request: req, fileURL: logFile.url) { result in
                 switch result {
-                    case .success(_): XCTFail("This request is not successful – the server is returning an error code")
+                    case .success: XCTFail("This request is not successful – the server is returning an error code")
                     case .failure(let error): XCTAssertNotNil(error)
                 }
 
@@ -59,14 +59,14 @@ class EventLoggingNetworkServiceTests: XCTestCase {
 
         let logFile = LogFile.containingRandomString()
         let req = URLRequest(url: testURL())
-        
+
         waitForExpectation(timeout: 1.0) { exp in
             service.uploadFile(request: req, fileURL: logFile.url) { result in
                 switch result {
                     case .success(let response):
                         let responseString = String(data: response!, encoding: .utf8)!
                         XCTAssertEqual(responseString, responseString)
-                    case .failure(_): XCTFail("This request should not fail")
+                    case .failure: XCTFail("This request should not fail")
                 }
 
                 exp.fulfill()
@@ -78,4 +78,3 @@ class EventLoggingNetworkServiceTests: XCTestCase {
         return URL(string: "http://\(testDomain)/\(path)")!
     }
 }
-

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingNetworkServiceTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingNetworkServiceTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import AutomatticTracks
+import OHHTTPStubs
+
+class EventLoggingNetworkServiceTests: XCTestCase {
+
+    var service: EventLoggingNetworkService!
+    private let testDomain = "upload-example.test"
+
+    override func setUp() {
+        super.setUp()
+        self.service = EventLoggingNetworkService()
+    }
+
+    override func tearDown() {
+        self.service = nil
+        HTTPStubs.removeAllStubs()
+    }
+
+    func testThatInvalidURLsFail() {
+        let logFile = LogFile.containingRandomString()
+        let req = URLRequest(url: URL(string: "invalid://location")!)
+
+        async_test(timeout: 1.0) { exp in
+            service.uploadFile(request: req, fileURL: logFile.url) { result in
+                switch result {
+                    case .success(_): XCTFail("This request should not be successful – the url is invalid")
+                    case .failure(let error): XCTAssertNotNil(error)
+                }
+
+                exp.fulfill()
+            }
+        }
+    }
+
+    func testThatHTTPStatusCodesOutside200SeriesReturnError() {
+        stubResponse(domain: testDomain, status: "server error", statusCode: 500)
+
+        let logFile = LogFile.containingRandomString()
+        let req = URLRequest(url: testURL())
+
+        async_test(timeout: 1.0) { exp in
+            service.uploadFile(request: req, fileURL: logFile.url) { result in
+                switch result {
+                    case .success(_): XCTFail("This request is not successful – the server is returning an error code")
+                    case .failure(let error): XCTAssertNotNil(error)
+                }
+
+                exp.fulfill()
+            }
+        }
+    }
+
+    func testThatHTTPSucessCodesReturnMessageBody() {
+        let responseString = String.randomString(length: 255)
+        stubResponse(domain: testDomain, status: responseString)
+
+        let logFile = LogFile.containingRandomString()
+        let req = URLRequest(url: testURL())
+
+        async_test(timeout: 1.0) { exp in
+            service.uploadFile(request: req, fileURL: logFile.url) { result in
+                switch result {
+                    case .success(let response):
+                        let responseString = String(data: response!, encoding: .utf8)!
+                        XCTAssertEqual(responseString, responseString)
+                    case .failure(_): XCTFail("This request should not fail")
+                }
+
+                exp.fulfill()
+            }
+        }
+    }
+
+    fileprivate func testURL(path: String = #function) -> URL {
+        return URL(string: "http://\(testDomain)/\(path)")!
+    }
+}
+

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingNetworkServiceTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingNetworkServiceTests.swift
@@ -15,6 +15,8 @@ class EventLoggingNetworkServiceTests: XCTestCase {
     override func tearDown() {
         self.service = nil
         HTTPStubs.removeAllStubs()
+
+        super.tearDown()
     }
 
     func testThatInvalidURLsFail() {

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
@@ -14,8 +14,11 @@ class EventLoggingUploadManagerTests: XCTestCase {
         dataSource = MockEventLoggingDataSource()
         networkService = MockEventLoggingNetworkService()
 
-        uploadManager = EventLoggingUploadManager(dataSource: dataSource, delegate: delegate)
-        uploadManager.networkService = networkService
+        uploadManager = EventLoggingUploadManager(
+            dataSource: dataSource,
+            delegate: delegate,
+            networkService: networkService
+        )
     }
 
     override func tearDown() {

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
@@ -3,17 +3,28 @@ import XCTest
 
 class EventLoggingUploadManagerTests: XCTestCase {
     var uploadManager: EventLoggingUploadManager!
-    var networkService = MockEventLoggingNetworkService()
+    var networkService: MockEventLoggingNetworkService!
     var delegate: MockEventLoggingDelegate!
     var dataSource: MockEventLoggingDataSource!
 
     override func setUp() {
+        super.setUp()
+
         delegate = MockEventLoggingDelegate()
         dataSource = MockEventLoggingDataSource()
         networkService = MockEventLoggingNetworkService()
 
         uploadManager = EventLoggingUploadManager(dataSource: dataSource, delegate: delegate)
         uploadManager.networkService = networkService
+    }
+
+    override func tearDown() {
+        uploadManager = nil
+        networkService = nil
+        delegate = nil
+        dataSource = nil
+
+        super.tearDown()
     }
 
     func testThatDelegateIsNotifiedOfNetworkStartAndCompletionForSuccess() {

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import AutomatticTracks
+
+class EventLoggingUploadManagerTests: XCTestCase {
+    var uploadManager = EventLoggingUploadManager()
+    var networkService = MockEventLoggingNetworkService()
+    var delegate: MockEventLoggingDelegate!
+
+    override func setUp() {
+        delegate = MockEventLoggingDelegate()
+        networkService = MockEventLoggingNetworkService()
+
+        uploadManager.networkService = networkService
+        uploadManager.dataSource = MockEventLoggingDataSource()
+        uploadManager.delegate = delegate
+    }
+
+    func testThatDelegateIsNotifiedOfNetworkStartAndCompletionForSuccess() {
+
+        async_test(timeout: 1.0) { exp in
+            uploadManager.upload(LogFile.containingRandomString(), then:  { _ in exp.fulfill() })
+        }
+
+        XCTAssertTrue(delegate.didStartUploadingTriggered)
+        XCTAssertTrue(delegate.didFinishUploadingTriggered)
+        XCTAssertFalse(delegate.uploadCancelledByDelegateTriggered)
+    }
+
+    func testThatDelegateIsNotifiedOfNetworkStartForFailure() {
+
+        async_test(timeout: 1.0) { exp in
+            networkService.shouldSucceed = false
+            uploadManager.upload(LogFile.containingRandomString(), then:  { _ in exp.fulfill() })
+        }
+
+        XCTAssertTrue(delegate.didStartUploadingTriggered)
+        XCTAssertFalse(delegate.didFinishUploadingTriggered)
+        XCTAssertFalse(delegate.uploadCancelledByDelegateTriggered)
+    }
+
+    func testThatNetworkStartDoesNotFireWhenDelegateCancelsUpload() {
+
+        async_test(timeout: 1.0) { exp in
+            delegate.setShouldUploadLogFiles(false)
+            delegate.uploadCancelledByDelegateCallback = { _ in exp.fulfill() }
+            uploadManager.upload(LogFile.containingRandomString(), then:  { _ in XCTFail("Callback should not be called") })
+        }
+
+        XCTAssertFalse(delegate.didStartUploadingTriggered)
+        XCTAssertFalse(delegate.didFinishUploadingTriggered)
+        XCTAssertTrue(delegate.uploadCancelledByDelegateTriggered)
+    }
+
+    func testThatDelegateIsNotifiedOfMissingFiles() {
+        async_test(timeout: 1.0) { exp in
+            delegate.setShouldUploadLogFiles(true)
+            delegate.uploadFailedCallback = { error, _ in exp.fulfill() }
+            uploadManager.upload(LogFile.withInvalidPath(), then:  { _ in XCTFail("Callback should not be called") })
+        }
+    }
+}

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
@@ -33,7 +33,7 @@ class EventLoggingUploadManagerTests: XCTestCase {
     func testThatDelegateIsNotifiedOfNetworkStartAndCompletionForSuccess() {
 
         waitForExpectation(timeout: 1.0) { exp in
-            uploadManager.upload(LogFile.containingRandomString(), then:  { _ in exp.fulfill() })
+            uploadManager.upload(LogFile.containingRandomString(), then: { _ in exp.fulfill() })
         }
 
         XCTAssertTrue(delegate.didStartUploadingTriggered)
@@ -45,7 +45,7 @@ class EventLoggingUploadManagerTests: XCTestCase {
 
         waitForExpectation(timeout: 1.0) { exp in
             networkService.shouldSucceed = false
-            uploadManager.upload(LogFile.containingRandomString(), then:  { _ in exp.fulfill() })
+            uploadManager.upload(LogFile.containingRandomString(), then: { _ in exp.fulfill() })
         }
 
         XCTAssertTrue(delegate.didStartUploadingTriggered)
@@ -58,7 +58,7 @@ class EventLoggingUploadManagerTests: XCTestCase {
         waitForExpectation(timeout: 1.0) { exp in
             delegate.setShouldUploadLogFiles(false)
             delegate.uploadCancelledByDelegateCallback = { _ in exp.fulfill() }
-            uploadManager.upload(LogFile.containingRandomString(), then:  { _ in XCTFail("Callback should not be called") })
+            uploadManager.upload(LogFile.containingRandomString(), then: { _ in XCTFail("Callback should not be called") })
         }
 
         XCTAssertFalse(delegate.didStartUploadingTriggered)
@@ -70,7 +70,7 @@ class EventLoggingUploadManagerTests: XCTestCase {
         waitForExpectation(timeout: 1.0) { exp in
             delegate.setShouldUploadLogFiles(true)
             delegate.uploadFailedCallback = { error, _ in exp.fulfill() }
-            uploadManager.upload(LogFile.withInvalidPath(), then:  { _ in XCTFail("Callback should not be called") })
+            uploadManager.upload(LogFile.withInvalidPath(), then: { _ in XCTFail("Callback should not be called") })
         }
     }
 }

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
@@ -32,7 +32,7 @@ class EventLoggingUploadManagerTests: XCTestCase {
 
     func testThatDelegateIsNotifiedOfNetworkStartAndCompletionForSuccess() {
 
-        async_test(timeout: 1.0) { exp in
+        waitForExpectation(timeout: 1.0) { exp in
             uploadManager.upload(LogFile.containingRandomString(), then:  { _ in exp.fulfill() })
         }
 
@@ -43,7 +43,7 @@ class EventLoggingUploadManagerTests: XCTestCase {
 
     func testThatDelegateIsNotifiedOfNetworkStartForFailure() {
 
-        async_test(timeout: 1.0) { exp in
+        waitForExpectation(timeout: 1.0) { exp in
             networkService.shouldSucceed = false
             uploadManager.upload(LogFile.containingRandomString(), then:  { _ in exp.fulfill() })
         }
@@ -55,7 +55,7 @@ class EventLoggingUploadManagerTests: XCTestCase {
 
     func testThatNetworkStartDoesNotFireWhenDelegateCancelsUpload() {
 
-        async_test(timeout: 1.0) { exp in
+        waitForExpectation(timeout: 1.0) { exp in
             delegate.setShouldUploadLogFiles(false)
             delegate.uploadCancelledByDelegateCallback = { _ in exp.fulfill() }
             uploadManager.upload(LogFile.containingRandomString(), then:  { _ in XCTFail("Callback should not be called") })
@@ -67,7 +67,7 @@ class EventLoggingUploadManagerTests: XCTestCase {
     }
 
     func testThatDelegateIsNotifiedOfMissingFiles() {
-        async_test(timeout: 1.0) { exp in
+        waitForExpectation(timeout: 1.0) { exp in
             delegate.setShouldUploadLogFiles(true)
             delegate.uploadFailedCallback = { error, _ in exp.fulfill() }
             uploadManager.upload(LogFile.withInvalidPath(), then:  { _ in XCTFail("Callback should not be called") })

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
@@ -2,17 +2,18 @@ import XCTest
 @testable import AutomatticTracks
 
 class EventLoggingUploadManagerTests: XCTestCase {
-    var uploadManager = EventLoggingUploadManager()
+    var uploadManager: EventLoggingUploadManager!
     var networkService = MockEventLoggingNetworkService()
     var delegate: MockEventLoggingDelegate!
+    var dataSource: MockEventLoggingDataSource!
 
     override func setUp() {
         delegate = MockEventLoggingDelegate()
+        dataSource = MockEventLoggingDataSource()
         networkService = MockEventLoggingNetworkService()
 
+        uploadManager = EventLoggingUploadManager(dataSource: dataSource, delegate: delegate)
         uploadManager.networkService = networkService
-        uploadManager.dataSource = MockEventLoggingDataSource()
-        uploadManager.delegate = delegate
     }
 
     func testThatDelegateIsNotifiedOfNetworkStartAndCompletionForSuccess() {

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadQueueTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadQueueTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import AutomatticTracks
+
+class EventLoggingUploadQueueTests: XCTestCase {
+
+    var uploadQueue = EventLoggingUploadQueue()
+
+    override func setUp() {
+        uploadQueue = EventLoggingUploadQueue()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        let directory = uploadQueue.storageDirectory
+        if FileManager.default.directoryExistsAtURL(directory) {
+            try! FileManager.default.removeItem(at: directory)
+        }
+
+        XCTAssertTrue(!FileManager.default.directoryExistsAtURL(directory))
+    }
+
+    func testThatEmptyStorageDirectoryReturnsNilForFirstFile() {
+        XCTAssertNil(uploadQueue.first)
+    }
+
+    func testThatAddingAFileCreatesStorageDirectory() {
+        let log = LogFile.containingRandomString()
+        try! uploadQueue.add(log)
+        XCTAssertTrue(FileManager.default.directoryExistsAtURL(uploadQueue.storageDirectory))
+    }
+
+    func testThatAddingAFileCopiesItToStorageDirectory() {
+        let log = LogFile.containingRandomString()
+        try! uploadQueue.add(log)
+
+        let files = (try? FileManager.default.contentsOfDirectory(at: uploadQueue.storageDirectory)) ?? []
+        XCTAssertTrue(files.count == 1)
+    }
+
+    func testThatAddingAFileMakesItAvailableForRetrieval() {
+        let log = LogFile.containingRandomString()
+        try! uploadQueue.add(log)
+
+        guard let firstLog = uploadQueue.first else {
+            XCTFail("The queue must contain at least one log")
+            return
+        }
+
+        XCTAssertEqual(FileManager.default.contents(atUrl: log.url), FileManager.default.contents(atUrl: firstLog.url))
+    }
+
+    func testThatRemovingAFileRemovesItFromStorage() {
+        let log = LogFile.containingRandomString()
+        try! uploadQueue.add(log)
+
+        XCTAssertEqual(try! FileManager.default.contentsOfDirectory(at: uploadQueue.storageDirectory).count, 1)
+        try! uploadQueue.remove(log)
+        XCTAssertEqual(try! FileManager.default.contentsOfDirectory(at: uploadQueue.storageDirectory).count, 0)
+    }
+}

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadQueueTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadQueueTests.swift
@@ -3,20 +3,24 @@ import XCTest
 
 class EventLoggingUploadQueueTests: XCTestCase {
 
-    var uploadQueue = EventLoggingUploadQueue()
+    var uploadQueue: EventLoggingUploadQueue!
 
     override func setUp() {
+        super.setUp()
         uploadQueue = EventLoggingUploadQueue()
     }
 
     override func tearDown() {
-        super.tearDown()
         let directory = uploadQueue.storageDirectory
         if FileManager.default.directoryExistsAtURL(directory) {
             try! FileManager.default.removeItem(at: directory)
         }
 
         XCTAssertTrue(!FileManager.default.directoryExistsAtURL(directory))
+
+        uploadQueue = nil
+
+        super.tearDown()
     }
 
     func testThatEmptyStorageDirectoryReturnsNilForFirstFile() {

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadQueueTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadQueueTests.swift
@@ -57,4 +57,14 @@ class EventLoggingUploadQueueTests: XCTestCase {
         try! uploadQueue.remove(log)
         XCTAssertEqual(try! FileManager.default.contentsOfDirectory(at: uploadQueue.storageDirectory).count, 0)
     }
+
+    func testThatCustomFileUploadQueueLocationCreatesStorageDirectory() {
+        let log = LogFile.containingRandomString()
+
+        let customLocation = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        let customQueue = EventLoggingUploadQueue(storageDirectory: customLocation)
+        try! customQueue.add(log)
+
+        XCTAssert(FileManager.default.fileExistsAtURL(log.url))
+    }
 }

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/LogFileTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/LogFileTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import AutomatticTracks
+
+class LogFileTests: XCTestCase {
+
+    func testThatLogFileNameMatchesUUID() {
+        let log = LogFile.containingRandomString()
+        XCTAssertEqual(log.fileName, log.uuid)
+    }
+
+    func testParsingExistingFilenameUsesOnlyFilename() {
+        let fileName = UUID().uuidString
+        let contents = String.randomString(length: 255)
+        let testFile = FileManager.default.createTempFile(named: fileName, containing: contents)
+
+        let log = LogFile.fromExistingFile(at: testFile)
+        XCTAssertEqual(log.fileName, fileName)
+        XCTAssertEqual(log.uuid, fileName)
+    }
+
+    func testParsingExistingFilenameUsesOnlyFilenameIncludingExtension() {
+        let contents = String.randomString(length: 255)
+        let testFile = FileManager.default.createTempFile(named: "test.log", containing: contents)
+
+        let log = LogFile.fromExistingFile(at: testFile)
+        XCTAssertEqual(log.fileName, "test.log")
+        XCTAssertEqual(log.uuid, "test.log")
+    }
+}


### PR DESCRIPTION
Adds support for uploading encrypted logs. 

Assigned to both @oguzkocer and @shiki, though either (or both) can approve and provide comments as desired.

In the scope of review, I'd love if you're able to comment specifically on whether:
- All public method documentation is easy to read and understand.
- The use of preconditions + Implicitly Unwrapped Optionals in `EventLoggingUploadManager` seems reasonable. Not providing a delegate and a dataSource is a programmer error, so I used these to avoid a bunch of runtime error handling code that should never be called anyway.

**To Test:**
- Ensure CI passes
- Ensure tests pass locally