### PR TITLE
Fixes an Xcode warning in a test

### DIFF
--- a/Automattic-Tracks-iOSTests/Tests/TracksServiceTests.m
+++ b/Automattic-Tracks-iOSTests/Tests/TracksServiceTests.m
@@ -108,7 +108,7 @@
         return ([obj count] == 1);
     }]
                               withSharedProperties:[OCMArg isNotNil]
-                                 completionHandler:[OCMArg checkWithBlock:^BOOL(void (^passedBlock)()) {
+                                 completionHandler:[OCMArg checkWithBlock:^BOOL(void (^passedBlock)(NSError*)) {
         passedBlock(nil);
         
         return YES;


### PR DESCRIPTION
Just a little PR to fix a small nit.

**To Test:**
0. Ensure the PR is green.
1. In `develop`, run the unit test suite on your local machine. In the errors/warnings tab, Xcode will complain about the block syntax.
2. Run the test suite on your local machine from this branch. Xcode won't be complaining about it anymore.