### PR TITLE
Add encrypted logging upload authentication

### DIFF
--- a/Automattic-Tracks-iOS/Event Logging/EventLoggingDataSource.swift
+++ b/Automattic-Tracks-iOS/Event Logging/EventLoggingDataSource.swift
@@ -15,6 +15,9 @@ public protocol EventLoggingDataSource {
 
     /// The path to log upload queue storage
     var logUploadQueueStorageURL: URL { get }
+
+    /// The authentication token used for encrypted log upload
+    var loggingAuthenticationToken: String { get }
 }
 
 public extension EventLoggingDataSource {

--- a/Automattic-Tracks-iOSTests/Test Helpers/Mocks.swift
+++ b/Automattic-Tracks-iOSTests/Test Helpers/Mocks.swift
@@ -9,12 +9,13 @@ enum MockError: Error {
     case generic
 }
 
-struct MockEventLoggingDataSource: EventLoggingDataSource {
-    let loggingEncryptionKey: String
-    let previousSessionLogPath: URL?
-    var currentSessionLogPath: URL?
-    let logUploadURL: URL
-    let logUploadQueueStorageURL: URL
+class MockEventLoggingDataSource: EventLoggingDataSource {
+    private(set) var loggingEncryptionKey: String
+    private(set) var previousSessionLogPath: URL?
+    private(set) var currentSessionLogPath: URL?
+    private(set) var logUploadURL: URL
+    private(set) var logUploadQueueStorageURL: URL
+    private(set) var loggingAuthenticationToken: String = ""
 
     init(
         encryptionKey: String = "foo",
@@ -28,23 +29,19 @@ struct MockEventLoggingDataSource: EventLoggingDataSource {
     }
 
     func withLogUploadUrl(_ url: URL) -> Self {
-        return MockEventLoggingDataSource(
-            encryptionKey: self.loggingEncryptionKey,
-            sessionLogPath: self.previousSessionLogPath,
-            logUploadUrl: url,
-            queueUrl: self.logUploadQueueStorageURL
-        )
+        self.logUploadURL = url
+        return self
     }
 
     func withEncryptionKey() -> Self {
         let keyPair = Sodium().box.keyPair()!
+        self.loggingEncryptionKey = Data(keyPair.publicKey).base64EncodedString()
+        return self
+    }
 
-        return MockEventLoggingDataSource(
-            encryptionKey: Data(keyPair.publicKey).base64EncodedString(),
-            sessionLogPath: self.previousSessionLogPath,
-            logUploadUrl: self.logUploadURL,
-            queueUrl: self.logUploadQueueStorageURL
-        )
+    func withAuthenticationToken(_ token: String) -> Self {
+        self.loggingAuthenticationToken = token
+        return self
     }
 }
 

--- a/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
@@ -84,6 +84,32 @@ class EventLoggingUploadManagerTests: XCTestCase {
             })
         }
     }
+
+    func testThatRequestContainsCorrectUUID() {
+        let log = LogFile.containingRandomString()
+        let dataSource = MockEventLoggingDataSource()
+        let manager = uploadManager(dataSource: dataSource)
+
+        let request = manager.createRequest(url: dataSource.logUploadURL, uuid: log.uuid, authenticationToken: "")
+        XCTAssertEqual(log.uuid, request.allHTTPHeaderFields!["log-uuid"])
+    }
+
+    func testThatRequestContainsCorrectAuthenticationToken() {
+        let token = String.randomString(length: 64)
+        let dataSource = MockEventLoggingDataSource().withAuthenticationToken(token)
+        let manager = uploadManager(dataSource: dataSource)
+
+        let request = manager.createRequest(url: dataSource.logUploadURL, uuid: "", authenticationToken: token)
+        XCTAssertEqual(token, request.allHTTPHeaderFields!["Authorization"])
+    }
+
+    func testThatRequestUsesPostMethod() {
+        let dataSource = MockEventLoggingDataSource()
+        let manager = uploadManager(dataSource: dataSource)
+
+        let request = manager.createRequest(url: dataSource.logUploadURL, uuid: "", authenticationToken: "")
+        XCTAssertEqual("POST", request.httpMethod)
+    }
 }
 
 extension EventLoggingUploadManagerTests {
@@ -93,5 +119,13 @@ extension EventLoggingUploadManagerTests {
         dataSource: EventLoggingDataSource = MockEventLoggingDataSource()
     ) -> EventLoggingUploadManager {
         return EventLoggingUploadManager(dataSource: dataSource, delegate: delegate, networkService: networkService)
+    }
+
+    func uploadManager(dataSource: EventLoggingDataSource) -> EventLoggingUploadManager {
+        return uploadManager(
+            delegate: MockEventLoggingDelegate(),
+            networkService: MockEventLoggingNetworkService(),
+            dataSource: dataSource
+        )
     }
 }


### PR DESCRIPTION
Adds support for the `Authorization` header with the data provided by the host app.

Reworks the test setup a bit in order to test the request creation in isolation.