### PR TITLE
Simplify the Log File Interface

### DIFF
--- a/Automattic-Tracks-iOS/Event Logging/EventLogging+Sentry.swift
+++ b/Automattic-Tracks-iOS/Event Logging/EventLogging+Sentry.swift
@@ -38,10 +38,13 @@ extension EventLogging {
 
 extension Event {
     var errorType: EventLoggingErrorType {
-        if self.level == .fatal {
+        switch self.level {
+        case .fatal:
             return .fatal
+        case .error, .warning, .info, .debug:
+            return .debug
+        @unknown default:
+            return .debug
         }
-
-        return .debug
     }
 }

--- a/Automattic-Tracks-iOS/Event Logging/EventLogging+Sentry.swift
+++ b/Automattic-Tracks-iOS/Event Logging/EventLogging+Sentry.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Sentry
 
+public enum EventLoggingErrorType {
+    case fatal
+    case debug
+}
+
 extension EventLogging {
     func attachLogToEventIfNeeded(event: Event) {
 
@@ -9,24 +14,34 @@ extension EventLogging {
             return
         }
 
-        /// We use the previous session's log for fatal errors because that session has presumably ended with the app crashing. If that's not the case,
-        /// the hosting app can handle that situation.
-        let logFilePath: URL?
-        switch event.level {
-            case .fatal: logFilePath = dataSource.previousSessionLogPath
-            default: logFilePath = dataSource.currentSessionLogPath
+        /// Allow the hosting app to determine the most appropriate log file to send for the error type. For example, in an application using
+        /// session-based file logging, the newest log file would be the current session, which is appropriate for debugging logs. However,
+        /// the previous session's log file is the correct one for a crash, because when the crash is sent there will already be a new log
+        /// file for the current session. Other apps may use time-based logs, in which case the same log would be the correct one.
+        ///
+        /// We also pass the timestamp for the event, as that can be useful for determining the correct log file.
+        guard let logFilePath = dataSource.logFilePath(forErrorLevel: event.errorType, at: event.timestamp) else {
+            return
         }
 
         /// Schedule the log file for upload, if available
-        if let logFilePath = logFilePath {
-            do {
-                let logFile = LogFile(url: logFilePath)
-                try enqueueLogForUpload(log: logFile)
-                event.logID = logFile.uuid
-            }
-            catch let err {
-                CrashLogging.logError(err)
-            }
+        do {
+            let logFile = LogFile(url: logFilePath)
+            try enqueueLogForUpload(log: logFile)
+            event.logID = logFile.uuid
         }
+        catch let err {
+            CrashLogging.logError(err)
+        }
+    }
+}
+
+extension Event {
+    var errorType: EventLoggingErrorType {
+        if self.level == .fatal {
+            return .fatal
+        }
+
+        return .debug
     }
 }

--- a/Automattic-Tracks-iOS/Event Logging/EventLoggingDataSource.swift
+++ b/Automattic-Tracks-iOS/Event Logging/EventLoggingDataSource.swift
@@ -7,17 +7,14 @@ public protocol EventLoggingDataSource {
     /// The URL to the upload endpoint for encrypted logs.
     var logUploadURL: URL { get }
 
-    /// The path to the log file for the most recent session.
-    var previousSessionLogPath: URL? { get }
-
-    /// The path to the log file for the current session.
-    var currentSessionLogPath: URL? { get }
-
     /// The path to log upload queue storage
     var logUploadQueueStorageURL: URL { get }
 
     /// The authentication token used for encrypted log upload
     var loggingAuthenticationToken: String { get }
+
+    /// Provides the log file corresponding to a given error type (if it exists)
+    func logFilePath(forErrorLevel: EventLoggingErrorType, at date: Date) -> URL?
 }
 
 public extension EventLoggingDataSource {

--- a/Automattic-Tracks-iOSTests/Test Helpers/Mocks.swift
+++ b/Automattic-Tracks-iOSTests/Test Helpers/Mocks.swift
@@ -11,21 +11,24 @@ enum MockError: Error {
 
 class MockEventLoggingDataSource: EventLoggingDataSource {
     private(set) var loggingEncryptionKey: String
-    private(set) var previousSessionLogPath: URL?
-    private(set) var currentSessionLogPath: URL?
     private(set) var logUploadURL: URL
     private(set) var logUploadQueueStorageURL: URL
     private(set) var loggingAuthenticationToken: String = ""
+    private let sessionLogPath: URL?
 
     init(
         encryptionKey: String = "foo",
         sessionLogPath: URL? = nil,
         logUploadUrl: URL = URL(string: "example.com")!,
         queueUrl: URL = FileManager.default.documentsDirectory.appendingPathComponent(UUID().uuidString)) {
-        loggingEncryptionKey = encryptionKey
-        previousSessionLogPath = sessionLogPath
-        logUploadURL = logUploadUrl
-        logUploadQueueStorageURL = queueUrl
+        self.loggingEncryptionKey = encryptionKey
+        self.logUploadURL = logUploadUrl
+        self.logUploadQueueStorageURL = queueUrl
+        self.sessionLogPath = sessionLogPath
+    }
+
+    func logFilePath(forErrorLevel: EventLoggingErrorType, at date: Date) -> URL? {
+        return sessionLogPath
     }
 
     func withLogUploadUrl(_ url: URL) -> Self {


### PR DESCRIPTION
This PR allows the hosting app to provide log files based on event severity and the timestamp of the event.

This should reduce the complexity of implementation in this library and in clients implementing it, while remaining flexible enough to handle the weirdness of different log file storage policies.
 