### PR TITLE
 Fix width and height tracking

### DIFF
--- a/Automattic-Tracks-iOS/Services/TracksService.m
+++ b/Automattic-Tracks-iOS/Services/TracksService.m
@@ -40,8 +40,8 @@ NSString *const DeviceInfoOSVersionKey = @"device_info_os_version";
 NSString *const DeviceInfoBrandKey = @"device_info_brand";
 NSString *const DeviceInfoManufacturerKey = @"device_info_manufacturer";
 NSString *const DeviceInfoModelKey = @"device_info_model";
-NSString *const DeviceInfoHeightPixelsKey = @"device_info_display_height";
-NSString *const DeviceInfoWidthPixelsKey = @"device_info_display_width";
+NSString *const DeviceInfoHeightKey = @"device_info_display_height";
+NSString *const DeviceInfoWidthKey = @"device_info_display_width";
 NSString *const DeviceInfoNetworkOperatorKey = @"device_info_current_network_operator";
 NSString *const DeviceInfoRadioTypeKey = @"device_info_phone_radio_type";
 NSString *const DeviceInfoWiFiConnectedKey = @"device_info_wifi_connected";
@@ -318,8 +318,8 @@ NSString *const USER_ID_ANON = @"anonId";
               DeviceInfoModelKey : self.deviceInformation.model ?: @"Unknown",
               DeviceInfoOSKey : self.deviceInformation.os ?: @"Unknown",
               DeviceInfoOSVersionKey : self.deviceInformation.version ?: @"Unknown",
-              DeviceInfoHeightPixelsKey : @(screenSize.height) ?: @0,
-              DeviceInfoWidthPixelsKey : @(screenSize.width) ?: @0,
+              DeviceInfoHeightKey : @(screenSize.height) ?: @0,
+              DeviceInfoWidthKey : @(screenSize.width) ?: @0,
               DeviceLanguageKey : self.deviceInformation.deviceLanguage ?: @"Unknown",
               TracksUserAgentKey : self.userAgent,
               };

--- a/Automattic-Tracks-iOS/Services/TracksService.m
+++ b/Automattic-Tracks-iOS/Services/TracksService.m
@@ -31,8 +31,6 @@ NSString *const TrackServiceWillSendQueuedEventsNotification = @"TrackServiceDid
 NSString *const TrackServiceDidSendQueuedEventsNotification = @"TrackServiceDidSendQueuedEventsNotification";
 
 NSString *const RequestTimestampKey = @"_rt";
-NSString *const DeviceHeightPixelsKey = @"_ht";
-NSString *const DeviceWidthPixelsKey = @"_wd";
 NSString *const DeviceLanguageKey = @"_lg";
 NSString *const DeviceInfoAppNameKey = @"device_info_app_name";
 NSString *const DeviceInfoAppVersionKey = @"device_info_app_version";
@@ -42,6 +40,8 @@ NSString *const DeviceInfoOSVersionKey = @"device_info_os_version";
 NSString *const DeviceInfoBrandKey = @"device_info_brand";
 NSString *const DeviceInfoManufacturerKey = @"device_info_manufacturer";
 NSString *const DeviceInfoModelKey = @"device_info_model";
+NSString *const DeviceInfoHeightPixelsKey = @"device_info_display_height";
+NSString *const DeviceInfoWidthPixelsKey = @"device_info_display_width";
 NSString *const DeviceInfoNetworkOperatorKey = @"device_info_current_network_operator";
 NSString *const DeviceInfoRadioTypeKey = @"device_info_phone_radio_type";
 NSString *const DeviceInfoWiFiConnectedKey = @"device_info_wifi_connected";
@@ -318,8 +318,8 @@ NSString *const USER_ID_ANON = @"anonId";
               DeviceInfoModelKey : self.deviceInformation.model ?: @"Unknown",
               DeviceInfoOSKey : self.deviceInformation.os ?: @"Unknown",
               DeviceInfoOSVersionKey : self.deviceInformation.version ?: @"Unknown",
-              DeviceHeightPixelsKey : @(screenSize.height) ?: @0,
-              DeviceWidthPixelsKey : @(screenSize.width) ?: @0,
+              DeviceInfoHeightPixelsKey : @(screenSize.height) ?: @0,
+              DeviceInfoWidthPixelsKey : @(screenSize.width) ?: @0,
               DeviceLanguageKey : self.deviceInformation.deviceLanguage ?: @"Unknown",
               TracksUserAgentKey : self.userAgent,
               };

--- a/Automattic-Tracks-iOS/TracksConstants.m
+++ b/Automattic-Tracks-iOS/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.5.0";
+NSString *const TracksLibraryVersion = @"0.5.1-beta.1";


### PR DESCRIPTION
Renames the height and width global params from `_ht` and `_wd` to `device_info_display_height` and `device_info_display_width` respectively.

I recently learned that the previous params were deprecated earlier this year, so they're currently not getting stored and historical data is also no longer available. The new ones are named consistently with Android and the general device info format.

Background: p4qSXL-3xm-p2

Corresponding Android PR: https://github.com/Automattic/Automattic-Tracks-Android/pull/48

I'm afraid I have absolutely no experience with updating pods so I humbly ask for help with getting this into the actual WPiOS app once merged. 🙏

### To test
1. Build WPiOS with this version of the Tracks library
2. Hook up a network listener like Charles, run WPAndroid, and wait for a tracks event to be broadcast (https://public-api.wordpress.com/rest/v1.1/tracks/record)
3. Examine the data sent, you should see a `commonProps` object which should include height/width information:
```js
"commonProps": {
  ...
  "device_info_display_height": "2160",
  "device_info_display_width": "1080",
  ...
```
9. Also confirm that the `_ht` and `_wd` props are no longer included