### PR TITLE
Remove nil coalescing for non-optional value in CrashLogging

### DIFF
--- a/Automattic-Tracks-iOS/Crash Logging/CrashLogging.swift
+++ b/Automattic-Tracks-iOS/Crash Logging/CrashLogging.swift
@@ -85,7 +85,7 @@ public class CrashLogging {
 
         #if DEBUG
         DDLogDebug("📜 This is a debug build")
-        let shouldSendEvent = UserDefaults.standard.bool(forKey: "force-crash-logging") ?? false
+        let shouldSendEvent = UserDefaults.standard.bool(forKey: "force-crash-logging")
         #else
         let shouldSendEvent = !CrashLogging.userHasOptedOut
         #endif


### PR DESCRIPTION
The code generated this warning:

> Left side of nil coalescing operator '??' has non-optional type
> 'Bool', so the right side is never used

I noticed it while working on AutoProxxy.