### PR TITLE
Add option to configure Tracks to store its DB in Application Support instead of Documents

### DIFF
--- a/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
+++ b/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3F3919ED25256B5300E56994 /* TracksContexManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3919EC25256B5300E56994 /* TracksContexManagerTests.swift */; };
 		4FE1FBB22B5CC44AC0EC7CBF /* Pods_Automattic_Tracks_OSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D834F2F168F81BD31598B29 /* Pods_Automattic_Tracks_OSX.framework */; };
 		57AB7ED12486C50900187234 /* ApplicationFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AB7ED02486C50900187234 /* ApplicationFacade.swift */; };
 		57AB7ED22486C50900187234 /* ApplicationFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AB7ED02486C50900187234 /* ApplicationFacade.swift */; };
@@ -167,6 +168,7 @@
 		3458F6511F3E809224A4A8DB /* Pods-Automattic_Tracks_OSXTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic_Tracks_OSXTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic_Tracks_OSXTests/Pods-Automattic_Tracks_OSXTests.debug.xcconfig"; sourceTree = "<group>"; };
 		371F24E5742FCBB4490DD9A9 /* Pods-Automattic-Tracks-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Tracks-iOSTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Tracks-iOSTests/Pods-Automattic-Tracks-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		3AF418C8EF68BCAA9CA82B3C /* Pods-Automattic_Tracks_OSXTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic_Tracks_OSXTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic_Tracks_OSXTests/Pods-Automattic_Tracks_OSXTests.release.xcconfig"; sourceTree = "<group>"; };
+		3F3919EC25256B5300E56994 /* TracksContexManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksContexManagerTests.swift; sourceTree = "<group>"; };
 		4D23D263D998EA01CCB752C4 /* Pods-Automattic-Tracks-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Tracks-iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Tracks-iOS/Pods-Automattic-Tracks-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		519B82281CDF10E002CD67A7 /* Pods_Automattic_Tracks_OSXTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Automattic_Tracks_OSXTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		57AB7ED02486C50900187234 /* ApplicationFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationFacade.swift; sourceTree = "<group>"; };
@@ -516,6 +518,7 @@
 			children = (
 				F99D032E2422D9F30091C33E /* Event Logging */,
 				F99D032C2422D9F30091C33E /* CrashLoggingTests.swift */,
+				3F3919EC25256B5300E56994 /* TracksContexManagerTests.swift */,
 				F99D032D2422D9F30091C33E /* TracksEventServiceTests.m */,
 				F99D03302422D9F30091C33E /* TracksEventTests.m */,
 				F99D03312422D9F30091C33E /* TracksServiceRemoteIntegrationTests.m */,
@@ -962,6 +965,7 @@
 				F99D033C2422D9F30091C33E /* TracksServiceRemoteIntegrationTests.m in Sources */,
 				F99D03292422D9B70091C33E /* TestTracksContextManager.m in Sources */,
 				F99D03212422D9B70091C33E /* Extensions.swift in Sources */,
+				3F3919ED25256B5300E56994 /* TracksContexManagerTests.swift in Sources */,
 				F94EE62C242C4C280015C18E /* LogFileTests.swift in Sources */,
 				F99D033A2422D9F30091C33E /* TracksEventTests.m in Sources */,
 				F944565B24296698009A36B3 /* Mocks.swift in Sources */,

--- a/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.h
+++ b/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.h
@@ -3,8 +3,8 @@
 
 @interface TracksContextManager : NSObject
 
-@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
-@property (nonatomic, strong) NSManagedObjectModel *managedObjectModel;
-@property (nonatomic, strong) NSPersistentStoreCoordinator *persistentStoreCoordinator;
+@property (nonnull, nonatomic, strong) NSManagedObjectContext *managedObjectContext;
+@property (nonnull, nonatomic, strong) NSManagedObjectModel *managedObjectModel;
+@property (nonnull, nonatomic, strong) NSPersistentStoreCoordinator *persistentStoreCoordinator;
 
 @end

--- a/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.h
+++ b/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.h
@@ -7,4 +7,18 @@
 @property (nonnull, nonatomic, strong) NSManagedObjectModel *managedObjectModel;
 @property (nonnull, nonatomic, strong) NSPersistentStoreCoordinator *persistentStoreCoordinator;
 
+/// In version 0.5.1 and earlier, the CoreData store was always saved in the Documents folder.
+///
+/// This approach is fine for sandboxed applications distributed via the Mac App Store, but would
+/// result in the user being asked for access to the `~/Documents` folder in non-sandboxed apps.
+///
+/// To avoid this bad UX – which also blocks tests in CI with the same alert – when the app is
+/// sandboxed, we can save the store in `~/Application Support`.
+///
+/// This designated initializer allows consumers to tell `TracksContextManager` the mode in which
+/// the app is running and where to save the store.
+///
+/// The `super` `init` method defaults to `false` for backward compatibility.
+- (nonnull instancetype)initWithSandboxedMode:(BOOL)sandboxed NS_DESIGNATED_INITIALIZER;
+
 @end

--- a/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
+++ b/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
@@ -42,7 +42,7 @@
     // Create the coordinator and store
     
     _persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[self managedObjectModel]];
-    NSURL *storeURL = [[self applicationSupportURLForContainerApp] URLByAppendingPathComponent:@"Tracks.sqlite"];
+    NSURL *storeURL = [self storeURL];
     NSError *error = nil;
     if (![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
         
@@ -57,6 +57,11 @@
     }
     
     return _persistentStoreCoordinator;
+}
+
+- (NSURL *)storeURL {
+    NSURL *containerDirectoryURL = [self applicationSupportURLForContainerApp];
+    return [containerDirectoryURL URLByAppendingPathComponent:@"Tracks.sqlite"];
 }
 
 - (NSURL *)applicationSupportURLForContainerApp {

--- a/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
+++ b/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
@@ -10,7 +10,7 @@
 @implementation TracksContextManager
 
 - (instancetype)init {
-    return [[TracksContextManager alloc] initWithSandboxedMode:true];
+    return [self initWithSandboxedMode:true];
 }
 
 - (instancetype)initWithSandboxedMode:(BOOL)sandboxed {

--- a/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
+++ b/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
@@ -42,7 +42,7 @@
     // Create the coordinator and store
     
     _persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[self managedObjectModel]];
-    NSURL *storeURL = [[self applicationDocumentsDirectory] URLByAppendingPathComponent:@"Tracks.sqlite"];
+    NSURL *storeURL = [[self applicationSupportURLForContainerApp] URLByAppendingPathComponent:@"Tracks.sqlite"];
     NSError *error = nil;
     if (![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
         

--- a/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
+++ b/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
@@ -59,6 +59,52 @@
     return _persistentStoreCoordinator;
 }
 
+- (NSURL *)applicationSupportURLForContainerApp {
+    // The container app is the one owning the main bundle
+    return [self applicationSupportURLForAppWithBundleIdentifier:[[NSBundle mainBundle] bundleIdentifier]];
+}
+
+- (NSURL *)applicationSupportURLForAppWithBundleIdentifier:(NSString *)bundleIdentifier {
+    NSURL *folder = [[self applicationSupportURL] URLByAppendingPathComponent:bundleIdentifier];
+    NSError *error = nil;
+    [[NSFileManager defaultManager] createDirectoryAtURL:folder
+                             withIntermediateDirectories:true
+                                              attributes:nil
+                                                   error:&error];
+
+    // It seems safe not to handle this error because Application Support should always be
+    // available and one should always be able to create a folder in it
+    if (error != nil) {
+        DDLogError(@"Failed to create folder for %@ in Application Support: %@, %@", bundleIdentifier, error, [error userInfo]);
+        abort();
+    }
+
+    return folder;
+}
+
+// Application Support contains "the files that your app creates and manages on behalf of the user
+// and can include files that contain user data".
+//
+// See:
+// https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html#//apple_ref/doc/uid/TP40010672-CH10-SW1
+- (NSURL *)applicationSupportURL {
+    NSError *error = nil;
+    NSFileManager *manager = [NSFileManager defaultManager];
+    NSURL *applicationSupportURL = [manager URLForDirectory:NSApplicationSupportDirectory
+                                                inDomain:NSUserDomainMask
+                                       appropriateForURL:nil
+                                                  create:false
+                                                   error:&error];
+
+    // It seems safe not to handle this error because Application Support should always be
+    // available.
+    if (error != nil) {
+        DDLogError(@"Failed to get path to Application Support folder: %@, %@", error, [error userInfo]);
+        abort();
+    }
+
+    return applicationSupportURL;
+}
 
 - (NSManagedObjectContext *)managedObjectContext {
     // Returns the managed object context for the application (which is already bound to the persistent store coordinator for the application.)

--- a/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
+++ b/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
@@ -10,7 +10,7 @@
 @implementation TracksContextManager
 
 - (instancetype)init {
-    return [self initWithSandboxedMode:true];
+    return [self initWithSandboxedMode:YES];
 }
 
 - (instancetype)initWithSandboxedMode:(BOOL)sandboxed {
@@ -80,9 +80,9 @@
 
 - (NSURL *)storeContainerDirectoryURL {
     if (self.sandboxed == YES) {
-        return [self applicationSupportURLForContainerApp];
-    } else {
         return [self applicationDocumentsDirectory];
+    } else {
+        return [self applicationSupportURLForContainerApp];
     }
 }
 

--- a/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
+++ b/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
@@ -115,22 +115,9 @@
 // See:
 // https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html#//apple_ref/doc/uid/TP40010672-CH10-SW1
 - (NSURL *)applicationSupportURL {
-    NSError *error = nil;
-    NSFileManager *manager = [NSFileManager defaultManager];
-    NSURL *applicationSupportURL = [manager URLForDirectory:NSApplicationSupportDirectory
-                                                inDomain:NSUserDomainMask
-                                       appropriateForURL:nil
-                                                  create:false
-                                                   error:&error];
-
-    // It seems safe not to handle this error because Application Support should always be
-    // available.
-    if (error != nil) {
-        DDLogError(@"Failed to get path to Application Support folder: %@, %@", error, [error userInfo]);
-        abort();
-    }
-
-    return applicationSupportURL;
+    // Application Support should always be available, so no checking whether the array is empty
+    return [[[NSFileManager defaultManager] URLsForDirectory:NSApplicationSupportDirectory
+                                                   inDomains:NSUserDomainMask] lastObject];
 }
 
 - (NSManagedObjectContext *)managedObjectContext {

--- a/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
+++ b/Automattic-Tracks-iOS/Model/Core Data/TracksContextManager.m
@@ -3,9 +3,24 @@
 
 @interface TracksContextManager ()
 
+@property (nonatomic, assign) BOOL sandboxed;
+
 @end
 
 @implementation TracksContextManager
+
+- (instancetype)init {
+    return [[TracksContextManager alloc] initWithSandboxedMode:true];
+}
+
+- (instancetype)initWithSandboxedMode:(BOOL)sandboxed {
+    self = [super init];
+    if (!self) { return nil; }
+
+    self.sandboxed = sandboxed;
+
+    return self;
+}
 
 #pragma mark - Core Data stack
 
@@ -60,8 +75,15 @@
 }
 
 - (NSURL *)storeURL {
-    NSURL *containerDirectoryURL = [self applicationSupportURLForContainerApp];
-    return [containerDirectoryURL URLByAppendingPathComponent:@"Tracks.sqlite"];
+    return [[self storeContainerDirectoryURL] URLByAppendingPathComponent:@"Tracks.sqlite"];
+}
+
+- (NSURL *)storeContainerDirectoryURL {
+    if (self.sandboxed == YES) {
+        return [self applicationSupportURLForContainerApp];
+    } else {
+        return [self applicationDocumentsDirectory];
+    }
 }
 
 - (NSURL *)applicationSupportURLForContainerApp {

--- a/Automattic-Tracks-iOSTests/Automattic-Tracks-iOSTests-Bridging-Header.h
+++ b/Automattic-Tracks-iOSTests/Automattic-Tracks-iOSTests-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import "TracksServiceRemote.h"
+#import "TracksContextManager.h"

--- a/Automattic-Tracks-iOSTests/Tests/TracksContexManagerTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/TracksContexManagerTests.swift
@@ -1,0 +1,14 @@
+@testable import AutomatticTracks
+import XCTest
+
+class TracksContextManagerTests: XCTestCase {
+
+    func testStoreIsInApplicationSupportDirectory() throws {
+        let contextManager = TracksContextManager()
+
+        XCTAssertEqual(contextManager.persistentStoreCoordinator.persistentStores.count, 1)
+        let storeURL = try XCTUnwrap(contextManager.persistentStoreCoordinator.persistentStores.first?.url)
+
+        XCTAssertTrue(storeURL.pathComponents.contains("Application Support"))
+    }
+}

--- a/Automattic-Tracks-iOSTests/Tests/TracksContexManagerTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/TracksContexManagerTests.swift
@@ -3,12 +3,26 @@ import XCTest
 
 class TracksContextManagerTests: XCTestCase {
 
-    func testStoreIsInApplicationSupportDirectory() throws {
+    func testStoreIsInDocumentsDirectoryByDefault() throws {
         let contextManager = TracksContextManager()
-
-        XCTAssertEqual(contextManager.persistentStoreCoordinator.persistentStores.count, 1)
-        let storeURL = try XCTUnwrap(contextManager.persistentStoreCoordinator.persistentStores.first?.url)
-
+        let storeURL = try getStoreURLFrom(contextManager)
         XCTAssertTrue(storeURL.pathComponents.contains("Application Support"))
+    }
+
+    func testStoreIsInApplicationSupportDirectoryWhenSandboxed() throws {
+        let contextManager = TracksContextManager(sandboxedMode: true)
+        let storeURL = try getStoreURLFrom(contextManager)
+        XCTAssertTrue(storeURL.pathComponents.contains("Application Support"))
+    }
+
+    func testStoreIsInDocumentsDirectoryWhenNotSandboxed() throws {
+        let contextManager = TracksContextManager(sandboxedMode: false)
+        let storeURL = try getStoreURLFrom(contextManager)
+        XCTAssertTrue(storeURL.pathComponents.contains("Documents"))
+    }
+
+    private func getStoreURLFrom(_ manager: TracksContextManager) throws -> URL {
+        XCTAssertEqual(manager.persistentStoreCoordinator.persistentStores.count, 1)
+        return try XCTUnwrap(manager.persistentStoreCoordinator.persistentStores.first?.url)
     }
 }

--- a/Automattic-Tracks-iOSTests/Tests/TracksContexManagerTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/TracksContexManagerTests.swift
@@ -6,17 +6,17 @@ class TracksContextManagerTests: XCTestCase {
     func testStoreIsInDocumentsDirectoryByDefault() throws {
         let contextManager = TracksContextManager()
         let storeURL = try getStoreURLFrom(contextManager)
-        XCTAssertTrue(storeURL.pathComponents.contains("Application Support"))
+        XCTAssertTrue(storeURL.pathComponents.contains("Documents"))
     }
 
-    func testStoreIsInApplicationSupportDirectoryWhenSandboxed() throws {
-        let contextManager = TracksContextManager(sandboxedMode: true)
+    func testStoreIsInApplicationSupportDirectoryWhenNotSandboxed() throws {
+        let contextManager = TracksContextManager(sandboxedMode: false)
         let storeURL = try getStoreURLFrom(contextManager)
         XCTAssertTrue(storeURL.pathComponents.contains("Application Support"))
     }
 
-    func testStoreIsInDocumentsDirectoryWhenNotSandboxed() throws {
-        let contextManager = TracksContextManager(sandboxedMode: false)
+    func testStoreIsInDocumentsDirectoryWhenSandboxed() throws {
+        let contextManager = TracksContextManager(sandboxedMode: true)
         let storeURL = try getStoreURLFrom(contextManager)
         XCTAssertTrue(storeURL.pathComponents.contains("Documents"))
     }


### PR DESCRIPTION
See #146.

~~This is just a test to verify my internal non-sandboxed macOS app works fine when using Application Support.~~

Update: we decided to merge this change, but in a way that wouldn't change the behavior of Simplenote macOS.

To test these changes:

- I added unit tests 🙂, although CI is failing 🙃, but not because of my tests 🙂
- Checkout this PR in Simplenote macOS https://github.com/Automattic/simplenote-macos/pull/683