### PR TITLE
Adds AB Testing support (ExPlat)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ workflows:
           #
           # To work around that issue, look for Sodium-Fork in a secondary
           # source.
-          sources: "https://cdn.cocoapods.org/,https://github.com/mokagio/private-cocoapods-specs.git"
+          sources: "https://cdn.cocoapods.org/"
       - ios/publish-podspec:
           name: Publish pod to Trunk
           xcode-version: "12.0.0"

--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |spec|
   spec.ios.exclude_files = 'Automattic-Tracks-OSX/Automattic_Tracks_OSX.h'
 
   spec.osx.source_files = 'Automattic-Tracks-iOS/**/*.{h,m,swift}'
-  spec.osx.exclude_files = 'Automattic-Tracks-iOS/Automattic-Tracks-iOS.h'
+  spec.osx.exclude_files = ['Automattic-Tracks-iOS/Automattic-Tracks-iOS.h', 'Automattic-Tracks-iOS/ABTesting/*']
 
   spec.private_header_files = 'Automattic-Tracks-iOS/Internal Logging/TracksLoggingPrivate.h'
   spec.resource_bundle = { 'DataModel' => ['Automattic-Tracks-iOS/**/*.xcdatamodeld'] }

--- a/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
+++ b/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
@@ -13,6 +13,14 @@
 		57AB7ED22486C50900187234 /* ApplicationFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AB7ED02486C50900187234 /* ApplicationFacade.swift */; };
 		66B4025E8CC43C3928D21D6A /* Pods_Automattic_Tracks_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCA23FA76778DD4D62989FD4 /* Pods_Automattic_Tracks_iOSTests.framework */; };
 		89284FEF37B307C0A99A81E5 /* Pods_Automattic_Tracks_OSXTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 519B82281CDF10E002CD67A7 /* Pods_Automattic_Tracks_OSXTests.framework */; };
+		8BC5869E25557C1C0058D0F8 /* ExPlatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC5869C25557C1C0058D0F8 /* ExPlatTests.swift */; };
+		8BC5869F25557C1C0058D0F8 /* ExPlatServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC5869D25557C1C0058D0F8 /* ExPlatServiceTests.swift */; };
+		8BC586AB25557C650058D0F8 /* explat-assignments.json in Resources */ = {isa = PBXBuildFile; fileRef = 8BC586A925557C650058D0F8 /* explat-assignments.json */; };
+		8BC586AC25557C650058D0F8 /* explat-malformed-assignments.json in Resources */ = {isa = PBXBuildFile; fileRef = 8BC586AA25557C650058D0F8 /* explat-malformed-assignments.json */; };
+		8BC586B925557C740058D0F8 /* ABTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC586B525557C740058D0F8 /* ABTesting.swift */; };
+		8BC586BA25557C740058D0F8 /* Assignments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC586B625557C740058D0F8 /* Assignments.swift */; };
+		8BC586BB25557C740058D0F8 /* ExPlat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC586B725557C740058D0F8 /* ExPlat.swift */; };
+		8BC586BC25557C740058D0F8 /* ExPlatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC586B825557C740058D0F8 /* ExPlatService.swift */; };
 		93B5C7AE1CE25D40002820B3 /* Automattic-Tracks-iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B5C7AD1CE25D40002820B3 /* Automattic-Tracks-iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93B5C7B51CE25D40002820B3 /* AutomatticTracks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93B5C7AB1CE25D40002820B3 /* AutomatticTracks.framework */; };
 		93B5C7C21CE25D66002820B3 /* TracksLoggingPrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 93B5C7681CE230AD002820B3 /* TracksLoggingPrivate.m */; };
@@ -176,6 +184,14 @@
 		6CAA4DA76E13B617281D5E5C /* Pods-Automattic-Tracks-OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Tracks-OSX.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Tracks-OSX/Pods-Automattic-Tracks-OSX.debug.xcconfig"; sourceTree = "<group>"; };
 		6D834F2F168F81BD31598B29 /* Pods_Automattic_Tracks_OSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Automattic_Tracks_OSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8809A9D0B8C988BC31A6E219 /* Pods-Automattic-Tracks-iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Tracks-iOSTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Tracks-iOSTests/Pods-Automattic-Tracks-iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
+		8BC5869C25557C1C0058D0F8 /* ExPlatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExPlatTests.swift; sourceTree = "<group>"; };
+		8BC5869D25557C1C0058D0F8 /* ExPlatServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExPlatServiceTests.swift; sourceTree = "<group>"; };
+		8BC586A925557C650058D0F8 /* explat-assignments.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "explat-assignments.json"; sourceTree = "<group>"; };
+		8BC586AA25557C650058D0F8 /* explat-malformed-assignments.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "explat-malformed-assignments.json"; sourceTree = "<group>"; };
+		8BC586B525557C740058D0F8 /* ABTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ABTesting.swift; sourceTree = "<group>"; };
+		8BC586B625557C740058D0F8 /* Assignments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assignments.swift; sourceTree = "<group>"; };
+		8BC586B725557C740058D0F8 /* ExPlat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExPlat.swift; sourceTree = "<group>"; };
+		8BC586B825557C740058D0F8 /* ExPlatService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExPlatService.swift; sourceTree = "<group>"; };
 		9339E70A1ADE98B800AEAB68 /* TracksConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TracksConstants.h; sourceTree = "<group>"; };
 		9339E70B1ADE98B800AEAB68 /* TracksConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TracksConstants.m; sourceTree = "<group>"; };
 		9349E9921D41148A00DDB5BB /* Automattic-Tracks-iOSTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Automattic-Tracks-iOSTests-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -329,6 +345,35 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		8BC5869A25557B240058D0F8 /* ABTesting */ = {
+			isa = PBXGroup;
+			children = (
+				8BC586B525557C740058D0F8 /* ABTesting.swift */,
+				8BC586B625557C740058D0F8 /* Assignments.swift */,
+				8BC586B725557C740058D0F8 /* ExPlat.swift */,
+				8BC586B825557C740058D0F8 /* ExPlatService.swift */,
+			);
+			path = ABTesting;
+			sourceTree = "<group>";
+		};
+		8BC5869B25557B7B0058D0F8 /* ABTesting */ = {
+			isa = PBXGroup;
+			children = (
+				8BC5869D25557C1C0058D0F8 /* ExPlatServiceTests.swift */,
+				8BC5869C25557C1C0058D0F8 /* ExPlatTests.swift */,
+			);
+			path = ABTesting;
+			sourceTree = "<group>";
+		};
+		8BC586A825557C4F0058D0F8 /* Mock Data */ = {
+			isa = PBXGroup;
+			children = (
+				8BC586A925557C650058D0F8 /* explat-assignments.json */,
+				8BC586AA25557C650058D0F8 /* explat-malformed-assignments.json */,
+			);
+			path = "Mock Data";
+			sourceTree = "<group>";
+		};
 		93B5C7661CE2308D002820B3 /* Internal Logging */ = {
 			isa = PBXGroup;
 			children = (
@@ -367,6 +412,7 @@
 		93C0211B1AB0A6330014096A /* Automattic-Tracks-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				8BC5869A25557B240058D0F8 /* ABTesting */,
 				F9788DEB2421B55A000A9BB5 /* Crash Logging */,
 				F911718B240F20B1009A1EC0 /* Event Logging */,
 				F9788D8024219D66000A9BB5 /* Model */,
@@ -385,6 +431,7 @@
 			children = (
 				93C021291AB0A6330014096A /* Supporting Files */,
 				F99D031A2422D9B70091C33E /* Test Helpers */,
+				8BC586A825557C4F0058D0F8 /* Mock Data */,
 				F99D032B2422D9F30091C33E /* Tests */,
 			);
 			path = "Automattic-Tracks-iOSTests";
@@ -516,6 +563,7 @@
 		F99D032B2422D9F30091C33E /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				8BC5869B25557B7B0058D0F8 /* ABTesting */,
 				F99D032E2422D9F30091C33E /* Event Logging */,
 				F99D032C2422D9F30091C33E /* CrashLoggingTests.swift */,
 				3F3919EC25256B5300E56994 /* TracksContexManagerTests.swift */,
@@ -739,6 +787,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8BC586AC25557C650058D0F8 /* explat-malformed-assignments.json in Resources */,
+				8BC586AB25557C650058D0F8 /* explat-assignments.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -912,7 +962,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8BC586BA25557C740058D0F8 /* Assignments.swift in Sources */,
 				F9788D9224219D66000A9BB5 /* TracksDeviceInformation.m in Sources */,
+				8BC586B925557C740058D0F8 /* ABTesting.swift in Sources */,
 				F9788D9024219D66000A9BB5 /* TracksEvent.m in Sources */,
 				F9A0D6D92420294B00D27C01 /* FileHandle+Extensions.swift in Sources */,
 				F9788D9C24219D66000A9BB5 /* TracksContextManager.m in Sources */,
@@ -931,6 +983,7 @@
 				F9788D8E24219D66000A9BB5 /* LogFile.swift in Sources */,
 				F9788D9E24219D66000A9BB5 /* TracksUser.swift in Sources */,
 				F9788DD92421B4EF000A9BB5 /* TracksService.m in Sources */,
+				8BC586BC25557C740058D0F8 /* ExPlatService.swift in Sources */,
 				F944563D242965E7009A36B3 /* EventLoggingUploadManager.swift in Sources */,
 				F99D034A2422DD100091C33E /* TestHelpers.swift in Sources */,
 				F97CBE6024B64BE200A845D7 /* CocoaLumberjack.swift in Sources */,
@@ -940,6 +993,7 @@
 				93B5C7CC1CE25D66002820B3 /* TracksLogging.m in Sources */,
 				F9788DE72421B4EF000A9BB5 /* WatchSessionManager.m in Sources */,
 				F9788DA72421A2BF000A9BB5 /* CrashLogging.swift in Sources */,
+				8BC586BB25557C740058D0F8 /* ExPlat.swift in Sources */,
 				F9788D9A24219D66000A9BB5 /* Tracks.xcdatamodeld in Sources */,
 				F9788DD72421B4EF000A9BB5 /* TracksEventPersistenceService.m in Sources */,
 				F9788DE52421B4EF000A9BB5 /* TracksEventService.m in Sources */,
@@ -952,6 +1006,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F99D033E2422D9F30091C33E /* TracksServiceTests.m in Sources */,
+				8BC5869E25557C1C0058D0F8 /* ExPlatTests.swift in Sources */,
 				F94EE632242D000E0015C18E /* EventLoggingNetworkServiceTests.swift in Sources */,
 				F99D03402422D9F30091C33E /* TracksServiceRemoteTests.swift in Sources */,
 				F94456522429666B009A36B3 /* EventLoggingUploadManagerTests.swift in Sources */,
@@ -964,6 +1019,7 @@
 				F99D03232422D9B70091C33E /* LogFile+TestHelpers.swift in Sources */,
 				F99D033C2422D9F30091C33E /* TracksServiceRemoteIntegrationTests.m in Sources */,
 				F99D03292422D9B70091C33E /* TestTracksContextManager.m in Sources */,
+				8BC5869F25557C1C0058D0F8 /* ExPlatServiceTests.swift in Sources */,
 				F99D03212422D9B70091C33E /* Extensions.swift in Sources */,
 				3F3919ED25256B5300E56994 /* TracksContexManagerTests.swift in Sources */,
 				F94EE62C242C4C280015C18E /* LogFileTests.swift in Sources */,

--- a/Automattic-Tracks-iOS/ABTesting/ABTesting.swift
+++ b/Automattic-Tracks-iOS/ABTesting/ABTesting.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public enum Variation: Equatable {
+    case control
+    case treatment
+    case other(String)
+    case unknown
+}
+
+/// A protocol that defines a A/B Testing provider
+///
+public protocol ABTesting {
+    /// Refresh the assigned experiments
+    func refresh(completion: (() -> Void)?)
+
+    /// Return an experiment variation
+    func experiment(_ name: String) -> Variation
+}

--- a/Automattic-Tracks-iOS/ABTesting/Assignments.swift
+++ b/Automattic-Tracks-iOS/ABTesting/Assignments.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Model that contains experiments variations and TTL
+///
+struct Assignments: Decodable {
+    /// Time in seconds until the `variations` should be considered stale.
+    let ttl: Int
+
+    /// Mapping from experiment name to variation name.
+    let variations: [String: String?]
+}

--- a/Automattic-Tracks-iOS/ABTesting/ExPlat.swift
+++ b/Automattic-Tracks-iOS/ABTesting/ExPlat.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-public class ExPlat: ABTesting {
+@objc public class ExPlat: NSObject, ABTesting {
     public static var shared: ExPlat!
 
     private let service: ExPlatService
@@ -22,8 +22,19 @@ public class ExPlat: ABTesting {
     public init(configuration: ExPlatConfiguration,
          service: ExPlatService? = nil) {
         self.service = service ?? ExPlatService(configuration: configuration)
+        super.init()
         subscribeToNotifications()
         ExPlat.shared = self
+    }
+
+    @objc public static func configure(platform: String,
+                      oAuthToken: String?,
+                      userAgent: String?,
+                      anonId: String?) {
+        _ = ExPlat(configuration: ExPlatConfiguration(platform: platform,
+                                                       oAuthToken: oAuthToken,
+                                                       userAgent: userAgent,
+                                                       anonId: anonId))
     }
 
     deinit {

--- a/Automattic-Tracks-iOS/ABTesting/ExPlat.swift
+++ b/Automattic-Tracks-iOS/ABTesting/ExPlat.swift
@@ -1,0 +1,129 @@
+import Foundation
+import UIKit
+
+public class ExPlat: ABTesting {
+    public static var shared: ExPlat!
+
+    private let service: ExPlatService
+
+    private let assignmentsKey = "ab-testing-assignments"
+    private let ttlDateKey = "ab-testing-ttl-date"
+
+    private var ttl: TimeInterval {
+        guard let ttlDate = UserDefaults.standard.object(forKey: ttlDateKey) as? Date else {
+            return 0
+        }
+
+        return ttlDate.timeIntervalSinceReferenceDate - Date().timeIntervalSinceReferenceDate
+    }
+
+    private(set) var scheduledTimer: Timer?
+
+    public init(configuration: ExPlatConfiguration,
+         service: ExPlatService? = nil) {
+        self.service = service ?? ExPlatService(configuration: configuration)
+        subscribeToNotifications()
+        ExPlat.shared = self
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
+    }
+
+    /// Only refresh if the TTL has expired
+    ///
+    public func refreshIfNeeded(completion: (() -> Void)? = nil) {
+        guard ttl > 0 else {
+            completion?()
+            scheduleRefresh()
+            return
+        }
+
+        refresh(completion: completion)
+    }
+
+    /// Force the assignments to refresh
+    ///
+    public func refresh(completion: (() -> Void)? = nil) {
+        service.getAssignments { [weak self] assignments in
+            guard let `self` = self,
+                  let assignments = assignments else {
+                completion?()
+                return
+            }
+
+            let validVariations = assignments.variations.filter { $0.value != nil }
+            UserDefaults.standard.setValue(validVariations, forKey: self.assignmentsKey)
+
+            var ttlDate = Date()
+            ttlDate.addTimeInterval(TimeInterval(assignments.ttl))
+            UserDefaults.standard.setValue(ttlDate, forKey: self.ttlDateKey)
+            self.scheduleRefresh()
+
+            completion?()
+        }
+    }
+
+    public func experiment(_ name: String) -> Variation {
+        guard let assignments = UserDefaults.standard.object(forKey: assignmentsKey) as? [String: String?],
+              case let variation?? = assignments[name] else {
+            return .unknown
+        }
+
+        switch variation {
+        case "control":
+            return .control
+        case "treatment":
+            return .treatment
+        default:
+            return .other(variation)
+        }
+    }
+
+    private func scheduleRefresh() {
+        if ttl > 0 {
+            scheduledTimer?.invalidate()
+
+            /// Schedule the refresh on a background thread
+            DispatchQueue.global(qos: .background).async { [weak self] in
+                guard let `self` = self else {
+                    return
+                }
+
+                self.scheduledTimer = Timer.scheduledTimer(withTimeInterval: self.ttl, repeats: true) { [weak self] timer in
+                    self?.refresh()
+                    timer.invalidate()
+                }
+
+                RunLoop.current.run()
+            }
+
+
+        } else {
+            refresh()
+        }
+    }
+
+    /// Check if the app is entering background and/or foreground
+    /// and start/stop the timers
+    ///
+    private func subscribeToNotifications() {
+        let notificationCenter = NotificationCenter.default
+        notificationCenter.addObserver(self, selector: #selector(applicationDidEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(applicationWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
+    }
+
+    /// When the app goes to background stop the timer
+    ///
+    @objc private func applicationDidEnterBackground() {
+        scheduledTimer?.invalidate()
+    }
+
+    /// When the app enter foreground refresh the assignments or
+    /// start the timer
+    ///
+    @objc private func applicationWillEnterForeground() {
+        refreshIfNeeded()
+    }
+}

--- a/Automattic-Tracks-iOS/ABTesting/ExPlatService.swift
+++ b/Automattic-Tracks-iOS/ABTesting/ExPlatService.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-public protocol ExPlatConfiguration {
-    var platform: String { get }
-    var oAuthToken: String? { get }
-    var userAgent: String? { get }
-    var anonId: String? { get }
+public struct ExPlatConfiguration {
+    var platform: String
+    var oAuthToken: String?
+    var userAgent: String?
+    var anonId: String?
 }
 
 public class ExPlatService {

--- a/Automattic-Tracks-iOS/ABTesting/ExPlatService.swift
+++ b/Automattic-Tracks-iOS/ABTesting/ExPlatService.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+public protocol ExPlatConfiguration {
+    var platform: String { get }
+    var oAuthToken: String? { get }
+    var userAgent: String? { get }
+    var anonId: String? { get }
+}
+
+public class ExPlatService {
+    let platform: String
+    let oAuthToken: String?
+    let userAgent: String?
+    let anonId: String?
+
+    var assignmentsEndpoint: String {
+        return "https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/\(platform)"
+    }
+
+    init(configuration: ExPlatConfiguration) {
+        self.platform = configuration.platform
+        self.oAuthToken = configuration.oAuthToken
+        self.userAgent = configuration.userAgent
+        self.anonId = configuration.anonId
+    }
+
+    func getAssignments(completion: @escaping (Assignments?) -> Void) {
+        guard var urlComponents = URLComponents(string: assignmentsEndpoint) else {
+            completion(nil)
+            return
+        }
+
+        // Query items
+        urlComponents.queryItems = [URLQueryItem(name: "_locale", value: Locale.current.languageCode)]
+
+        if let anonId = anonId {
+            urlComponents.queryItems?.append(URLQueryItem.init(name: "anon_id", value: anonId))
+        }
+
+        guard let url = urlComponents.url else {
+            completion(nil)
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        // HTTP fields (including oAuthToken if provided)
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let oAuthToken = oAuthToken {
+            request.setValue( "Bearer \(oAuthToken)", forHTTPHeaderField: "Authorization")
+        }
+
+        // User-Agent
+        if let userAgent = userAgent {
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        }
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            guard let data = data, error == nil else {
+                completion(nil)
+                return
+            }
+
+            do {
+                let decoder = JSONDecoder()
+                let assignments = try decoder.decode(Assignments.self, from: data)
+                completion(assignments)
+            } catch {
+                DDLogError("Error parsing the experiment response: \(error)")
+                completion(nil)
+            }
+        }
+
+        task.resume()
+    }
+}

--- a/Automattic-Tracks-iOS/Services/TracksService.h
+++ b/Automattic-Tracks-iOS/Services/TracksService.h
@@ -27,7 +27,7 @@ extern NSString *const TrackServiceDidSendQueuedEventsNotification;
 - (NSDictionary *)dictionaryForTracksEvent:(TracksEvent *)tracksEvent withParentCommonProperties:(NSDictionary *)parentCommonProperties;
 
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent;
-- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID token:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent;
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent;
 - (void)switchToAnonymousUserWithAnonymousID:(NSString *)anonymousID;
 
 - (void)trackEventName:(NSString *)eventName;

--- a/Automattic-Tracks-iOS/Services/TracksService.h
+++ b/Automattic-Tracks-iOS/Services/TracksService.h
@@ -26,7 +26,7 @@ extern NSString *const TrackServiceDidSendQueuedEventsNotification;
 
 - (NSDictionary *)dictionaryForTracksEvent:(TracksEvent *)tracksEvent withParentCommonProperties:(NSDictionary *)parentCommonProperties;
 
-- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent;
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID token:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent;
 - (void)switchToAnonymousUserWithAnonymousID:(NSString *)anonymousID;
 
 - (void)trackEventName:(NSString *)eventName;

--- a/Automattic-Tracks-iOS/Services/TracksService.h
+++ b/Automattic-Tracks-iOS/Services/TracksService.h
@@ -26,6 +26,7 @@ extern NSString *const TrackServiceDidSendQueuedEventsNotification;
 
 - (NSDictionary *)dictionaryForTracksEvent:(TracksEvent *)tracksEvent withParentCommonProperties:(NSDictionary *)parentCommonProperties;
 
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent;
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID token:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent;
 - (void)switchToAnonymousUserWithAnonymousID:(NSString *)anonymousID;
 

--- a/Automattic-Tracks-iOS/Services/TracksService.m
+++ b/Automattic-Tracks-iOS/Services/TracksService.m
@@ -205,7 +205,7 @@ NSString *const USER_ID_ANON = @"anonId";
     }
 }
 
-- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID token:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
 {
     [self switchToAuthenticatedUserWithUsername:username userID:userID skipAliasEventCreation:skipEvent];
 

--- a/Automattic-Tracks-iOS/Services/TracksService.m
+++ b/Automattic-Tracks-iOS/Services/TracksService.m
@@ -201,7 +201,9 @@ NSString *const USER_ID_ANON = @"anonId";
     self.userID = userID;
     self.token = token;
 
+    #if TARGET_OS_IPHONE
     [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:token userAgent:self.userAgent anonId:nil];
+    #endif
     
     if (skipEvent == NO && previousUserID.length > 0) {
        [self.tracksEventService createTracksEventForAliasingWordPressComUser:username userID:userID withAnonymousUserID:previousUserID];
@@ -218,7 +220,9 @@ NSString *const USER_ID_ANON = @"anonId";
     self.userID = anonymousID;
     self.token = nil;
 
+    #if TARGET_OS_IPHONE
     [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:nil userAgent:self.userAgent anonId:anonymousID];
+    #endif
 }
 
 

--- a/Automattic-Tracks-iOS/Services/TracksService.m
+++ b/Automattic-Tracks-iOS/Services/TracksService.m
@@ -190,7 +190,7 @@ NSString *const USER_ID_ANON = @"anonId";
     [self.tracksEventService clearTracksEvents];
 }
 
-- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID token:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent
 {
     NSParameterAssert(username.length != 0 || userID.length != 0);
     
@@ -199,17 +199,22 @@ NSString *const USER_ID_ANON = @"anonId";
     self.anonymous = NO;
     self.username = username;
     self.userID = userID;
-    self.token = token;
-
-    #if TARGET_OS_IPHONE
-    [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:token userAgent:self.userAgent anonId:nil];
-    #endif
     
     if (skipEvent == NO && previousUserID.length > 0) {
        [self.tracksEventService createTracksEventForAliasingWordPressComUser:username userID:userID withAnonymousUserID:previousUserID];
     }
 }
 
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID token:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
+{
+    [self switchToAuthenticatedUserWithUsername:username userID:userID skipAliasEventCreation:skipEvent];
+
+    self.token = token;
+
+    #if TARGET_OS_IPHONE
+    [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:token userAgent:self.userAgent anonId:nil];
+    #endif
+}
 
 - (void)switchToAnonymousUserWithAnonymousID:(NSString *)anonymousID
 {

--- a/Automattic-Tracks-iOS/Services/TracksService.m
+++ b/Automattic-Tracks-iOS/Services/TracksService.m
@@ -2,6 +2,7 @@
 #import "TracksDeviceInformation.h"
 #import "TracksLoggingPrivate.h"
 #import <Reachability/Reachability.h>
+#import <AutomatticTracks/AutomatticTracks-Swift.h>
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -22,6 +23,7 @@
 @property (nonatomic, readonly) NSString *userAgent;
 @property (nonatomic, copy) NSString *username;
 @property (nonatomic, copy) NSString *userID;
+@property (nonatomic, copy) NSString *token;
 @property (nonatomic, assign, getter=isAnonymous) BOOL anonymous;
 
 @end
@@ -188,7 +190,7 @@ NSString *const USER_ID_ANON = @"anonId";
     [self.tracksEventService clearTracksEvents];
 }
 
-- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID token:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
 {
     NSParameterAssert(username.length != 0 || userID.length != 0);
     
@@ -197,6 +199,9 @@ NSString *const USER_ID_ANON = @"anonId";
     self.anonymous = NO;
     self.username = username;
     self.userID = userID;
+    self.token = token;
+
+    [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:token userAgent:self.userAgent anonId:nil];
     
     if (skipEvent == NO && previousUserID.length > 0) {
        [self.tracksEventService createTracksEventForAliasingWordPressComUser:username userID:userID withAnonymousUserID:previousUserID];
@@ -211,6 +216,9 @@ NSString *const USER_ID_ANON = @"anonId";
     self.anonymous = YES;
     self.username = @"";
     self.userID = anonymousID;
+    self.token = nil;
+
+    [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:nil userAgent:self.userAgent anonId:anonymousID];
 }
 
 

--- a/Automattic-Tracks-iOS/TracksConstants.m
+++ b/Automattic-Tracks-iOS/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.6.0";
+NSString *const TracksLibraryVersion = @"0.7.0";

--- a/Automattic-Tracks-iOSTests/Mock Data/explat-assignments.json
+++ b/Automattic-Tracks-iOSTests/Mock Data/explat-assignments.json
@@ -1,0 +1,6 @@
+{
+    "variations": {
+        "experiment": "control"
+    },
+    "ttl": 60
+}

--- a/Automattic-Tracks-iOSTests/Mock Data/explat-malformed-assignments.json
+++ b/Automattic-Tracks-iOSTests/Mock Data/explat-malformed-assignments.json
@@ -1,0 +1,3 @@
+{
+    malformed
+}

--- a/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatServiceTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatServiceTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+import OHHTTPStubs
+
+@testable import AutomatticTracks
+
+class ExPlatServiceTests: XCTestCase {
+    override func tearDown() {
+        super.tearDown()
+
+        HTTPStubs.removeAllStubs()
+    }
+
+    // Return TTL and variations
+    //
+    func testRefresh() {
+        let expectation = XCTestExpectation(description: "Return assignments")
+        stubAssignmentsResponseWithFile("explat-assignments.json")
+        let service = ExPlatService(configuration: ExPlatTestConfiguration())
+
+        service.getAssignments { assignments in
+            XCTAssertEqual(assignments?.ttl, 60)
+            XCTAssertEqual(assignments?.variations, ["experiment": "control"])
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    // Do not return assignments when the decoding fails
+    //
+    func testRefreshDecodeFails() {
+        let expectation = XCTestExpectation(description: "Do not return assignments")
+        stubAssignmentsResponseWithFile("explat-malformed-assignments.json")
+        let service = ExPlatService(configuration: ExPlatTestConfiguration())
+
+        service.getAssignments { assignments in
+            XCTAssertNil(assignments)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    // Do not return assignments when the server returns an error
+    //
+    func testRefreshServerFails() {
+        let expectation = XCTestExpectation(description: "Do not return assignments")
+        stubAssignmentsResponseWithError()
+        let service = ExPlatService(configuration: ExPlatTestConfiguration())
+
+        service.getAssignments { assignments in
+            XCTAssertNil(assignments)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    private func stubAssignmentsResponseWithFile(_ filename: String) {
+        stubAssignments(withFile: filename)
+    }
+
+    private func stubAssignmentsResponseWithError() {
+        stubAssignments(withFile: "explat-malformed-assignments.json", withStatus: 503)
+    }
+
+    private func stubAssignments(withFile file: String = "explat-assignments.json", withStatus status: Int32? = nil) {
+        let endpoint = "wpcom/v2/experiments/0.1.0/assignments/wpios_test"
+        stub(condition: { request in
+            return (request.url!.absoluteString as NSString).contains(endpoint) && request.httpMethod! == "GET"
+        }) { _ in
+            let stubPath = OHPathForFile(file, type(of: self))
+            return fixture(filePath: stubPath!, status: status ?? 200, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
+        }
+    }
+}
+
+class ExPlatTestConfiguration: ExPlatConfiguration {
+    var platform = "wpios_test"
+
+    var oAuthToken: String?
+
+    var userAgent: String?
+
+    var anonId: String?
+}

--- a/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatServiceTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatServiceTests.swift
@@ -4,6 +4,13 @@ import OHHTTPStubs
 @testable import AutomatticTracks
 
 class ExPlatServiceTests: XCTestCase {
+    var exPlatTestConfiguration = ExPlatConfiguration(
+        platform: "wpios_test",
+        oAuthToken: nil,
+        userAgent: nil,
+        anonId: nil
+    )
+
     override func tearDown() {
         super.tearDown()
 
@@ -15,7 +22,7 @@ class ExPlatServiceTests: XCTestCase {
     func testRefresh() {
         let expectation = XCTestExpectation(description: "Return assignments")
         stubAssignmentsResponseWithFile("explat-assignments.json")
-        let service = ExPlatService(configuration: ExPlatTestConfiguration())
+        let service = ExPlatService(configuration: exPlatTestConfiguration)
 
         service.getAssignments { assignments in
             XCTAssertEqual(assignments?.ttl, 60)
@@ -31,7 +38,7 @@ class ExPlatServiceTests: XCTestCase {
     func testRefreshDecodeFails() {
         let expectation = XCTestExpectation(description: "Do not return assignments")
         stubAssignmentsResponseWithFile("explat-malformed-assignments.json")
-        let service = ExPlatService(configuration: ExPlatTestConfiguration())
+        let service = ExPlatService(configuration: exPlatTestConfiguration)
 
         service.getAssignments { assignments in
             XCTAssertNil(assignments)
@@ -46,7 +53,7 @@ class ExPlatServiceTests: XCTestCase {
     func testRefreshServerFails() {
         let expectation = XCTestExpectation(description: "Do not return assignments")
         stubAssignmentsResponseWithError()
-        let service = ExPlatService(configuration: ExPlatTestConfiguration())
+        let service = ExPlatService(configuration: exPlatTestConfiguration)
 
         service.getAssignments { assignments in
             XCTAssertNil(assignments)
@@ -73,14 +80,4 @@ class ExPlatServiceTests: XCTestCase {
             return fixture(filePath: stubPath!, status: status ?? 200, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
     }
-}
-
-class ExPlatTestConfiguration: ExPlatConfiguration {
-    var platform = "wpios_test"
-
-    var oAuthToken: String?
-
-    var userAgent: String?
-
-    var anonId: String?
 }

--- a/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatTests.swift
@@ -3,11 +3,18 @@ import XCTest
 @testable import AutomatticTracks
 
 class ExPlatTests: XCTestCase {
+    var exPlatTestConfiguration = ExPlatConfiguration(
+        platform: "wpios_test",
+        oAuthToken: nil,
+        userAgent: nil,
+        anonId: nil
+    )
+
     // Save the returned experiments variation
     //
     func testRefresh() {
         let expectation = XCTestExpectation(description: "Save experiments")
-        let abTesting = ExPlat(configuration: ExPlatTestConfiguration(), service: ExPlatServiceMock())
+        let abTesting = ExPlat(configuration: exPlatTestConfiguration, service: ExPlatServiceMock())
 
         abTesting.refresh {
             XCTAssertEqual(abTesting.experiment("experiment"), .control)
@@ -23,7 +30,7 @@ class ExPlatTests: XCTestCase {
     func testError() {
         let expectation = XCTestExpectation(description: "Keep experiments")
         let serviceMock = ExPlatServiceMock()
-        let abTesting = ExPlat(configuration: ExPlatTestConfiguration(), service: serviceMock)
+        let abTesting = ExPlat(configuration: exPlatTestConfiguration, service: serviceMock)
         abTesting.refresh {
 
             serviceMock.returnAssignments = false
@@ -43,7 +50,7 @@ class ExPlatTests: XCTestCase {
     func testScheduleRefresh() {
         let expectation = XCTestExpectation(description: "Automatically refresh")
         let serviceMock = ExPlatServiceMock()
-        let abTesting = ExPlat(configuration: ExPlatTestConfiguration(), service: serviceMock)
+        let abTesting = ExPlat(configuration: exPlatTestConfiguration, service: serviceMock)
         abTesting.refresh {
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -62,7 +69,12 @@ private class ExPlatServiceMock: ExPlatService {
     var returnAssignments = true
 
     init() {
-        super.init(configuration: ExPlatTestConfiguration())
+        super.init(configuration: ExPlatConfiguration(
+            platform: "wpios_test",
+            oAuthToken: nil,
+            userAgent: nil,
+            anonId: nil
+        ))
     }
 
     override func getAssignments(completion: @escaping (Assignments?) -> Void) {

--- a/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+
+@testable import AutomatticTracks
+
+class ExPlatTests: XCTestCase {
+    // Save the returned experiments variation
+    //
+    func testRefresh() {
+        let expectation = XCTestExpectation(description: "Save experiments")
+        let abTesting = ExPlat(configuration: ExPlatTestConfiguration(), service: ExPlatServiceMock())
+
+        abTesting.refresh {
+            XCTAssertEqual(abTesting.experiment("experiment"), .control)
+            XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    // Keep the already saved experiments in case of a failure
+    //
+    func testError() {
+        let expectation = XCTestExpectation(description: "Keep experiments")
+        let serviceMock = ExPlatServiceMock()
+        let abTesting = ExPlat(configuration: ExPlatTestConfiguration(), service: serviceMock)
+        abTesting.refresh {
+
+            serviceMock.returnAssignments = false
+            abTesting.refresh {
+                XCTAssertEqual(abTesting.experiment("experiment"), .control)
+                XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment)
+                expectation.fulfill()
+            }
+
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    // Schedule a timer to automatically refresh
+    //
+    func testScheduleRefresh() {
+        let expectation = XCTestExpectation(description: "Automatically refresh")
+        let serviceMock = ExPlatServiceMock()
+        let abTesting = ExPlat(configuration: ExPlatTestConfiguration(), service: serviceMock)
+        abTesting.refresh {
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                XCTAssertTrue(abTesting.scheduledTimer!.isValid)
+                XCTAssertEqual(round(abTesting.scheduledTimer!.timeInterval), 60)
+                expectation.fulfill()
+            }
+
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+}
+
+private class ExPlatServiceMock: ExPlatService {
+    var returnAssignments = true
+
+    init() {
+        super.init(configuration: ExPlatTestConfiguration())
+    }
+
+    override func getAssignments(completion: @escaping (Assignments?) -> Void) {
+        guard returnAssignments else {
+            completion(nil)
+            return
+        }
+
+        completion(
+            Assignments(
+                ttl: 60,
+                variations: [
+                    "experiment": "control",
+                    "another_experiment": "treatment",
+                    "expired_experiment": nil
+                ]
+            )
+        )
+    }
+}


### PR DESCRIPTION
This PR adds AB Testing support.

### Configuration

(WPiOS PR here: https://github.com/wordpress-mobile/WordPress-iOS/pull/15236)

Before having fun with AB testing, the app needs to configure the ExPlat instance. To do so, the `switchToAuthenticatedUserWithUsername` method was changed and now it requires a `token` parameter.

An example from WPiOS:

```swift
[self.tracksService switchToAuthenticatedUserWithUsername:username userID:@"" token:self.token skipAliasEventCreation:NO];
```

Then, you need to call the method `refreshIfNeeded()` in `didFinishLaunchingWithOptions`.

```swift
ExPlat.shared.refreshIfNeeded()
```

And that's all. :)

### Usage

Once it's configured you can use like this:

```swift
switch ExPlat.shared.experiment("experiment-name") {
    case .treatment:
        // Show treatment option
    case .control:
        // Show control option
    case .unknown:
        // Experiment doesn't exist or wasn't retrieved
    case .other(let value) where value == "my-value":
        // any other value 
}
```

Or, more simpler:

```swift
switch ExPlat.shared.experiment("experiment-name") {
    case .treatment:
        // Show treatment option
    default:
        // Show control option
}
```