### PR TITLE
ExPlat: remove "unknown" variation, handle null and not-returned cases

### DIFF
--- a/Automattic-Tracks-iOS/ABTesting/ABTesting.swift
+++ b/Automattic-Tracks-iOS/ABTesting/ABTesting.swift
@@ -4,7 +4,6 @@ public enum Variation: Equatable {
     case control
     case treatment
     case other(String)
-    case unknown
 }
 
 /// A protocol that defines a A/B Testing provider

--- a/Automattic-Tracks-iOS/ABTesting/ABTesting.swift
+++ b/Automattic-Tracks-iOS/ABTesting/ABTesting.swift
@@ -2,8 +2,7 @@ import Foundation
 
 public enum Variation: Equatable {
     case control
-    case treatment
-    case other(String)
+    case treatment(String?)
 }
 
 /// A protocol that defines a A/B Testing provider

--- a/Automattic-Tracks-iOS/ABTesting/ExPlat.swift
+++ b/Automattic-Tracks-iOS/ABTesting/ExPlat.swift
@@ -89,9 +89,9 @@ import Cocoa
         case "control":
             return .control
         case "treatment":
-            return .treatment
+            return .treatment(nil)
         default:
-            return .other(variation)
+            return .treatment(variation)
         }
     }
 

--- a/Automattic-Tracks-iOS/ABTesting/ExPlat.swift
+++ b/Automattic-Tracks-iOS/ABTesting/ExPlat.swift
@@ -82,7 +82,7 @@ import Cocoa
     public func experiment(_ name: String) -> Variation {
         guard let assignments = UserDefaults.standard.object(forKey: assignmentsKey) as? [String: String?],
               case let variation?? = assignments[name] else {
-            return .unknown
+            return .control
         }
 
         switch variation {

--- a/Automattic-Tracks-iOS/TracksConstants.m
+++ b/Automattic-Tracks-iOS/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.7.0";
+NSString *const TracksLibraryVersion = @"0.7.1";

--- a/Automattic-Tracks-iOSTests/Mock Data/explat-assignments.json
+++ b/Automattic-Tracks-iOSTests/Mock Data/explat-assignments.json
@@ -1,6 +1,6 @@
 {
     "variations": {
-        "experiment": "control"
+        "experiment": null
     },
     "ttl": 60
 }

--- a/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatServiceTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatServiceTests.swift
@@ -26,7 +26,7 @@ class ExPlatServiceTests: XCTestCase {
 
         service.getAssignments { assignments in
             XCTAssertEqual(assignments?.ttl, 60)
-            XCTAssertEqual(assignments?.variations, ["experiment": "control"])
+            XCTAssertEqual(assignments?.variations, ["experiment": nil])
             expectation.fulfill()
         }
 

--- a/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatTests.swift
@@ -87,9 +87,8 @@ private class ExPlatServiceMock: ExPlatService {
             Assignments(
                 ttl: 60,
                 variations: [
-                    "experiment": "control",
-                    "another_experiment": "treatment",
-                    "expired_experiment": nil
+                    "experiment": nil,
+                    "another_experiment": "treatment"
                 ]
             )
         )

--- a/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/ABTesting/ExPlatTests.swift
@@ -18,7 +18,8 @@ class ExPlatTests: XCTestCase {
 
         abTesting.refresh {
             XCTAssertEqual(abTesting.experiment("experiment"), .control)
-            XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment)
+            XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment(nil))
+            XCTAssertEqual(abTesting.experiment("experiment_multiple_variation"), .treatment("another_treatment"))
             expectation.fulfill()
         }
 
@@ -36,7 +37,8 @@ class ExPlatTests: XCTestCase {
             serviceMock.returnAssignments = false
             abTesting.refresh {
                 XCTAssertEqual(abTesting.experiment("experiment"), .control)
-                XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment)
+                XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment(nil))
+                XCTAssertEqual(abTesting.experiment("experiment_multiple_variation"), .treatment("another_treatment"))
                 expectation.fulfill()
             }
 
@@ -88,7 +90,8 @@ private class ExPlatServiceMock: ExPlatService {
                 ttl: 60,
                 variations: [
                     "experiment": nil,
-                    "another_experiment": "treatment"
+                    "another_experiment": "treatment",
+                    "experiment_multiple_variation": "another_treatment"
                 ]
             )
         )


### PR DESCRIPTION
This PR implements some changes in the AB testing feature based on @withinboredom comments in a [previous PR](https://github.com/Automattic/Automattic-Tracks-iOS/pull/155#pullrequestreview-571332826):

* Remove the `unknown` variation. The default fallback is `control`
* If the experiment has a `null` value in the JSON, treat it as `control`
* If the experiment is not returned in the JSON, treat it as `control`
* Removes the `other()` variation. All variations are effectively a treatment variation, the API was slightly changed:

```swift
            switch abTesting.experiment("experiment") {
            case .treatment(let variation) where variation == "variation-name":
                // do something
            case .treatment(_):
                // default variation
            case .control:
                // control
            }
```

### How to test

Code review and green CI should be enough. :)