### PR TITLE
ExPlat: change platform to wpcom

### DIFF
--- a/Automattic-Tracks-iOS/Services/TracksService.m
+++ b/Automattic-Tracks-iOS/Services/TracksService.m
@@ -212,7 +212,8 @@ NSString *const USER_ID_ANON = @"anonId";
     self.token = token;
 
     #if TARGET_OS_IPHONE
-    [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:token userAgent:self.userAgent anonId:nil];
+    // Temporarily uses wpcom while we test that the implementation is not biased
+    [ExPlat configureWithPlatform:@"wpcom" oAuthToken:token userAgent:self.userAgent anonId:nil];
     #endif
 }
 
@@ -226,7 +227,8 @@ NSString *const USER_ID_ANON = @"anonId";
     self.token = nil;
 
     #if TARGET_OS_IPHONE
-    [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:nil userAgent:self.userAgent anonId:anonymousID];
+    // Temporarily uses wpcom while we test that the implementation is not biased
+    [ExPlat configureWithPlatform:@"wpcom" oAuthToken:nil userAgent:self.userAgent anonId:anonymousID];
     #endif
 }
 

--- a/Automattic-Tracks-iOS/TracksConstants.m
+++ b/Automattic-Tracks-iOS/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.8.0";
+NSString *const TracksLibraryVersion = @"0.8.1";


### PR DESCRIPTION
This PR changes the ExPlat platform temporarily to `wpcom` in order to test if the implementation is biased.

After the results, `wpios` will be added as a platform.