### PR TITLE
Add bundle identifier to events

### DIFF
--- a/Automattic-Tracks-iOS/Model/TracksDeviceInformation.h
+++ b/Automattic-Tracks-iOS/Model/TracksDeviceInformation.h
@@ -12,6 +12,7 @@
 @property (nonatomic, readonly) NSString *appName;
 @property (nonatomic, readonly) NSString *appVersion;
 @property (nonatomic, readonly) NSString *appBuild;
+@property (nonatomic, readonly) NSString *bundleIdentifier;
 
 // This information has the tendency to change
 @property (nonatomic, readonly) NSString *deviceLanguage;

--- a/Automattic-Tracks-iOS/Model/TracksDeviceInformation.m
+++ b/Automattic-Tracks-iOS/Model/TracksDeviceInformation.m
@@ -218,4 +218,9 @@
     return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
 }
 
+- (NSString *)bundleIdentifier
+{
+    return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"];
+}
+
 @end

--- a/Automattic-Tracks-iOS/Services/TracksService.m
+++ b/Automattic-Tracks-iOS/Services/TracksService.m
@@ -37,6 +37,7 @@ NSString *const DeviceLanguageKey = @"_lg";
 NSString *const DeviceInfoAppNameKey = @"device_info_app_name";
 NSString *const DeviceInfoAppVersionKey = @"device_info_app_version";
 NSString *const DeviceInfoAppBuildKey = @"device_info_app_version_code";
+NSString *const DeviceInfoBundleIdentifier = @"device_info_app_bundle_identifier";
 NSString *const DeviceInfoOSKey = @"device_info_os";
 NSString *const DeviceInfoOSVersionKey = @"device_info_os_version";
 NSString *const DeviceInfoBrandKey = @"device_info_brand";
@@ -332,6 +333,7 @@ NSString *const USER_ID_ANON = @"anonId";
               DeviceInfoAppBuildKey : self.deviceInformation.appBuild ?: @"Unknown",
               DeviceInfoAppNameKey : self.deviceInformation.appName ?: @"Unknown",
               DeviceInfoAppVersionKey : self.deviceInformation.appVersion ?: @"Unknown",
+              DeviceInfoBundleIdentifier : self.deviceInformation.bundleIdentifier ?: @"Unknown",
               DeviceInfoBrandKey : self.deviceInformation.brand ?: @"Unknown",
               DeviceInfoManufacturerKey : self.deviceInformation.manufacturer ?: @"Unknown",
               DeviceInfoModelKey : self.deviceInformation.model ?: @"Unknown",


### PR DESCRIPTION
Adds the app bundle identifier to events:

<img width="1004" alt="Screen Shot 2021-02-04 at 5 00 30 PM" src="https://user-images.githubusercontent.com/1123407/106970616-86924980-670a-11eb-8caf-7725924c8a8e.png">
