### PR TITLE
Don’t send localized strings to Sentry

### DIFF
--- a/Automattic-Tracks-OSX/TestPlan.xctestplan
+++ b/Automattic-Tracks-OSX/TestPlan.xctestplan
@@ -1,0 +1,34 @@
+{
+  "configurations" : [
+    {
+      "id" : "43D9D783-F602-42CB-8D17-8AB49900BF70",
+      "name" : "French",
+      "options" : {
+
+      }
+    },
+    {
+      "id" : "153DE951-4EDA-4ECE-990F-FB05EE8408D1",
+      "name" : "English",
+      "options" : {
+        "language" : "en",
+        "region" : "US"
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "language" : "fr",
+    "region" : "FR"
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Automattic-Tracks-iOS.xcodeproj",
+        "identifier" : "F970F41A21E7BBD8000664D2",
+        "name" : "Automattic_Tracks_OSXTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
+++ b/Automattic-Tracks-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		24464FB625B60E0000A34B78 /* SentryTestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24464FAF25B60E0000A34B78 /* SentryTestError.swift */; };
 		24464FB725B60E0000A34B78 /* SentryClient+Shim.h in Headers */ = {isa = PBXBuildFile; fileRef = 24464FB025B60E0000A34B78 /* SentryClient+Shim.h */; };
 		24464FB825B60E0000A34B78 /* SentryClient+Shim.h in Headers */ = {isa = PBXBuildFile; fileRef = 24464FB025B60E0000A34B78 /* SentryClient+Shim.h */; };
+		24A0CAD426030887008E793B /* SentryEvent+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A0CAD326030887008E793B /* SentryEvent+Extensions.swift */; };
+		24A0CAD526030887008E793B /* SentryEvent+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A0CAD326030887008E793B /* SentryEvent+Extensions.swift */; };
+		24A0CB0126030B7B008E793B /* SentryExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A0CB0026030B7B008E793B /* SentryExtensionTests.swift */; };
 		3F3919ED25256B5300E56994 /* TracksContexManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3919EC25256B5300E56994 /* TracksContexManagerTests.swift */; };
 		4FE1FBB22B5CC44AC0EC7CBF /* Pods_Automattic_Tracks_OSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D834F2F168F81BD31598B29 /* Pods_Automattic_Tracks_OSX.framework */; };
 		57AB7ED12486C50900187234 /* ApplicationFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AB7ED02486C50900187234 /* ApplicationFacade.swift */; };
@@ -193,6 +196,10 @@
 		24464FAE25B60E0000A34B78 /* SentryClient+Shim.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SentryClient+Shim.m"; sourceTree = "<group>"; };
 		24464FAF25B60E0000A34B78 /* SentryTestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentryTestError.swift; sourceTree = "<group>"; };
 		24464FB025B60E0000A34B78 /* SentryClient+Shim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SentryClient+Shim.h"; sourceTree = "<group>"; };
+		24A0CAD326030887008E793B /* SentryEvent+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SentryEvent+Extensions.swift"; sourceTree = "<group>"; };
+		24A0CB0026030B7B008E793B /* SentryExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryExtensionTests.swift; sourceTree = "<group>"; };
+		24A0CB0626030BF2008E793B /* TestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestPlan.xctestplan; sourceTree = "<group>"; };
+		24A0CB0C26030CB8008E793B /* TestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestPlan.xctestplan; sourceTree = "<group>"; };
 		3458F6511F3E809224A4A8DB /* Pods-Automattic_Tracks_OSXTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic_Tracks_OSXTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic_Tracks_OSXTests/Pods-Automattic_Tracks_OSXTests.debug.xcconfig"; sourceTree = "<group>"; };
 		371F24E5742FCBB4490DD9A9 /* Pods-Automattic-Tracks-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Tracks-iOSTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Tracks-iOSTests/Pods-Automattic-Tracks-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		3AF418C8EF68BCAA9CA82B3C /* Pods-Automattic_Tracks_OSXTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic_Tracks_OSXTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic_Tracks_OSXTests/Pods-Automattic_Tracks_OSXTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -566,6 +573,7 @@
 				24464FAE25B60E0000A34B78 /* SentryClient+Shim.m */,
 				24464FAD25B60E0000A34B78 /* SentryEventSerializer.swift */,
 				24464FAF25B60E0000A34B78 /* SentryTestError.swift */,
+				24A0CAD326030887008E793B /* SentryEvent+Extensions.swift */,
 			);
 			path = "Crash Logging";
 			sourceTree = "<group>";
@@ -597,6 +605,8 @@
 				F99D03332422D9F30091C33E /* TracksServiceRemoteTests.swift */,
 				F99D03322422D9F30091C33E /* TracksServiceTests.m */,
 				F9BB41302435B1C600533BCD /* TestExponentialBackoffTimer.swift */,
+				24A0CB0026030B7B008E793B /* SentryExtensionTests.swift */,
+				24A0CB0626030BF2008E793B /* TestPlan.xctestplan */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -619,6 +629,7 @@
 			children = (
 				F9A117B321E69B42002A5CD8 /* Automattic_Tracks_OSX.h */,
 				F9A117B421E69B42002A5CD8 /* Info.plist */,
+				24A0CB0C26030CB8008E793B /* TestPlan.xctestplan */,
 			);
 			path = "Automattic-Tracks-OSX";
 			sourceTree = "<group>";
@@ -1015,6 +1026,7 @@
 				F9788DD92421B4EF000A9BB5 /* TracksService.m in Sources */,
 				8BC586BC25557C740058D0F8 /* ExPlatService.swift in Sources */,
 				24464FB525B60E0000A34B78 /* SentryTestError.swift in Sources */,
+				24A0CAD426030887008E793B /* SentryEvent+Extensions.swift in Sources */,
 				F944563D242965E7009A36B3 /* EventLoggingUploadManager.swift in Sources */,
 				F99D034A2422DD100091C33E /* TestHelpers.swift in Sources */,
 				F97CBE6024B64BE200A845D7 /* CocoaLumberjack.swift in Sources */,
@@ -1038,6 +1050,7 @@
 			files = (
 				F99D033E2422D9F30091C33E /* TracksServiceTests.m in Sources */,
 				8BC5869E25557C1C0058D0F8 /* ExPlatTests.swift in Sources */,
+				24A0CB0126030B7B008E793B /* SentryExtensionTests.swift in Sources */,
 				F94EE632242D000E0015C18E /* EventLoggingNetworkServiceTests.swift in Sources */,
 				F99D03402422D9F30091C33E /* TracksServiceRemoteTests.swift in Sources */,
 				F94456522429666B009A36B3 /* EventLoggingUploadManagerTests.swift in Sources */,
@@ -1121,6 +1134,7 @@
 				F9788DDA2421B4EF000A9BB5 /* TracksService.m in Sources */,
 				F944563E242965E7009A36B3 /* EventLoggingUploadManager.swift in Sources */,
 				24464FB625B60E0000A34B78 /* SentryTestError.swift in Sources */,
+				24A0CAD526030887008E793B /* SentryEvent+Extensions.swift in Sources */,
 				F99D034B2422DD100091C33E /* TestHelpers.swift in Sources */,
 				57AB7ED22486C50900187234 /* ApplicationFacade.swift in Sources */,
 				F97CBE6124B64BE200A845D7 /* CocoaLumberjack.swift in Sources */,

--- a/Automattic-Tracks-iOS.xcodeproj/xcshareddata/xcschemes/Automattic-Tracks-OSX.xcscheme
+++ b/Automattic-Tracks-iOS.xcodeproj/xcshareddata/xcschemes/Automattic-Tracks-OSX.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1200"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -37,18 +37,12 @@
             ReferencedContainer = "container:Automattic-Tracks-iOS.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F970F41A21E7BBD8000664D2"
-               BuildableName = "Automattic_Tracks_OSXTests.xctest"
-               BlueprintName = "Automattic_Tracks_OSXTests"
-               ReferencedContainer = "container:Automattic-Tracks-iOS.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Automattic-Tracks-OSX/TestPlan.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Automattic-Tracks-iOS.xcodeproj/xcshareddata/xcschemes/Automattic-Tracks-iOS.xcscheme
+++ b/Automattic-Tracks-iOS.xcodeproj/xcshareddata/xcschemes/Automattic-Tracks-iOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1200"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -61,19 +61,12 @@
             ReferencedContainer = "container:Automattic-Tracks-iOS.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
-      <Testables>
-         <TestableReference
-            skipped = "NO"
-            testExecutionOrdering = "random">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "93B5C7B31CE25D40002820B3"
-               BuildableName = "Automattic-Tracks-iOSTests.xctest"
-               BlueprintName = "Automattic-Tracks-iOSTests"
-               ReferencedContainer = "container:Automattic-Tracks-iOS.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Automattic-Tracks-iOSTests/Tests/TestPlan.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Automattic-Tracks-iOS/Crash Logging/CrashLogging.swift
+++ b/Automattic-Tracks-iOS/Crash Logging/CrashLogging.swift
@@ -114,7 +114,7 @@ public extension CrashLogging {
         let event = Event(level: level)
 
         /// Use the unlocalized error message for better grouping
-        event.message = SentryMessage(formatted: (error as NSError).description)
+        event.message = SentryMessage(formatted: (error as NSError).debugDescription)
 
         /// If the developer provides their own userInfo, use that – otherwise read it from the Error
         event.extra = userInfo ?? (error as NSError).userInfo
@@ -156,7 +156,7 @@ public extension CrashLogging {
 
         errors.forEach { error in
             let event = Event(level: level)
-            event.message = SentryMessage(formatted: error.localizedDescription)
+            event.message = SentryMessage(formatted: (error as NSError).debugDescription)
             event.timestamp = Date()
             event.extra = userInfo ?? (error as NSError).userInfo
             event.user = dataProvider.currentUser?.sentryUser

--- a/Automattic-Tracks-iOS/Crash Logging/CrashLogging.swift
+++ b/Automattic-Tracks-iOS/Crash Logging/CrashLogging.swift
@@ -111,18 +111,13 @@ public extension CrashLogging {
     ///   - level: The level of severity to report in Sentry (`.error` by default)
     func logError(_ error: Error, userInfo: [String: Any]? = nil, level: SentryLevel = .error) {
 
-        let event = Event(level: level)
+        let userInfo = userInfo ?? (error as NSError).userInfo
 
-        /// Use the unlocalized error message for better grouping
-        event.message = SentryMessage(formatted: (error as NSError).debugDescription)
-
-        /// If the developer provides their own userInfo, use that – otherwise read it from the Error
-        event.extra = userInfo ?? (error as NSError).userInfo
-
-        /// Attach the localized description in case it has additional data
-        event.extra?["localized-description"] = error.localizedDescription
-
-        event.timestamp = Date()
+        let event = Event.from(
+            error: error as NSError,
+            level: level,
+            extra: userInfo
+        )
 
         SentrySDK.capture(event: event)
         dataProvider.didLogErrorCallback?(event)
@@ -155,11 +150,12 @@ public extension CrashLogging {
         var serializer = SentryEventSerializer(dsn: dataProvider.sentryDSN)
 
         errors.forEach { error in
-            let event = Event(level: level)
-            event.message = SentryMessage(formatted: (error as NSError).debugDescription)
-            event.timestamp = Date()
-            event.extra = userInfo ?? (error as NSError).userInfo
-            event.user = dataProvider.currentUser?.sentryUser
+            let event = Event.from(
+                error: error as NSError,
+                level: level,
+                user: dataProvider.currentUser?.sentryUser,
+                extra: userInfo ?? (error as NSError).userInfo
+            )
 
             serializer.add(event: addStackTrace(to: event))
         }

--- a/Automattic-Tracks-iOS/Crash Logging/SentryEvent+Extensions.swift
+++ b/Automattic-Tracks-iOS/Crash Logging/SentryEvent+Extensions.swift
@@ -10,11 +10,8 @@ extension Event {
     ) -> Event {
         let event = Event(level: level)
 
-        if let underlyingError = error.userInfo[NSUnderlyingErrorKey] as? NSError {
-            event.message = SentryMessage(formatted: underlyingError.debugDescription)
-        } else {
-            event.message = SentryMessage(formatted: error.debugDescription)
-        }
+        let baseError: NSError = (error.userInfo[NSUnderlyingErrorKey] as? NSError) ?? error
+        event.message = SentryMessage(formatted: baseError.debugDescription)
 
         /// The error code/domain can be used to reproduce the original error
         var mutableExtra = extra

--- a/Automattic-Tracks-iOS/Crash Logging/SentryEvent+Extensions.swift
+++ b/Automattic-Tracks-iOS/Crash Logging/SentryEvent+Extensions.swift
@@ -1,0 +1,33 @@
+import Sentry
+
+extension Event {
+    static func from(
+        error: NSError,
+        level: SentryLevel = .error,
+        user: Sentry.User? = nil,
+        timestamp: Date = Date(),
+        extra: [String: Any] = [:]
+    ) -> Event {
+        let event = Event(level: level)
+
+        if let underlyingError = error.userInfo[NSUnderlyingErrorKey] as? NSError {
+            event.message = SentryMessage(formatted: underlyingError.debugDescription)
+        } else {
+            event.message = SentryMessage(formatted: error.debugDescription)
+        }
+
+        /// The error code/domain can be used to reproduce the original error
+        var mutableExtra = extra
+        mutableExtra["error-code"] = error.code
+        mutableExtra["error-domain"] = error.domain
+
+        error.userInfo.forEach { (key, value) in
+            mutableExtra[key] = value
+        }
+
+        event.timestamp = timestamp
+        event.extra = [String:Any](uniqueKeysWithValues: mutableExtra.sorted { $0.key > $1.key })
+        event.user = user
+        return event
+    }
+}

--- a/Automattic-Tracks-iOS/Crash Logging/SentryEvent+Extensions.swift
+++ b/Automattic-Tracks-iOS/Crash Logging/SentryEvent+Extensions.swift
@@ -26,7 +26,7 @@ extension Event {
         }
 
         event.timestamp = timestamp
-        event.extra = [String: Any](uniqueKeysWithValues: mutableExtra.sorted { $0.key > $1.key })
+        event.extra = mutableExtra
         event.user = user
         return event
     }

--- a/Automattic-Tracks-iOS/Crash Logging/SentryEvent+Extensions.swift
+++ b/Automattic-Tracks-iOS/Crash Logging/SentryEvent+Extensions.swift
@@ -26,7 +26,7 @@ extension Event {
         }
 
         event.timestamp = timestamp
-        event.extra = [String:Any](uniqueKeysWithValues: mutableExtra.sorted { $0.key > $1.key })
+        event.extra = [String: Any](uniqueKeysWithValues: mutableExtra.sorted { $0.key > $1.key })
         event.user = user
         return event
     }

--- a/Automattic-Tracks-iOS/UI/Crash Logging/CrashLoggingView.swift
+++ b/Automattic-Tracks-iOS/UI/Crash Logging/CrashLoggingView.swift
@@ -21,6 +21,7 @@ public struct CrashLoggingView: View {
             Section(header: Text("Actions")) {
                 Button("Send Test Crash", action: sendTestCrash)
                 Button("Send Test Event", action: sendTestEvent)
+                Button("Send Test Error", action: sendTestError)
                 HStack {
                     Button(action: sendErrorAndWait) {
                         HStack {
@@ -72,6 +73,18 @@ extension CrashLoggingView {
 
     private func sendTestEvent() {
         crashLogging.logMessage("Test Event \(UUID().uuidString)")
+    }
+
+    private func sendTestError() {
+        do {
+            let path = FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .path
+            let _ = try Data(contentsOf: URL(fileURLWithPath: path))
+        } catch let err {
+            crashLogging.logError(err)
+        }
     }
 
     private func sendErrorAndWait() {

--- a/Automattic-Tracks-iOSTests/Tests/SentryExtensionTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/SentryExtensionTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import AutomatticTracks
+import Sentry
+
+class SentryExtensionTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testThatEventInitializationReturnsEnglishErrorDescription() {
+        do {
+            _ = try FileManager.default.attributesOfItem(at: URL(fileURLWithPath: "/not-a-real-path"))
+        } catch let err {
+            let event = Event.from(error: err as NSError)
+            XCTAssertEqual(event.message.formatted, "Error Domain=NSPOSIXErrorDomain Code=2 \"No such file or directory\"")
+        }
+    }
+}

--- a/Automattic-Tracks-iOSTests/Tests/SentryExtensionTests.swift
+++ b/Automattic-Tracks-iOSTests/Tests/SentryExtensionTests.swift
@@ -12,6 +12,8 @@ class SentryExtensionTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
+    // Note: for this test to be useful, it needs to be run as part of a Test Plan which runs the test suite
+    // in languages other than English. See TestPlan.xctestplan
     func testThatEventInitializationReturnsEnglishErrorDescription() {
         do {
             _ = try FileManager.default.attributesOfItem(at: URL(fileURLWithPath: "/not-a-real-path"))

--- a/Automattic-Tracks-iOSTests/Tests/TestPlan.xctestplan
+++ b/Automattic-Tracks-iOSTests/Tests/TestPlan.xctestplan
@@ -1,0 +1,34 @@
+{
+  "configurations" : [
+    {
+      "id" : "62B70EB6-6BFD-4B9C-8CF2-90F81870296E",
+      "name" : "French",
+      "options" : {
+
+      }
+    },
+    {
+      "id" : "D6CC9A18-0F7D-44BF-9306-61FE4444D3A1",
+      "name" : "English",
+      "options" : {
+        "language" : "en",
+        "region" : "US"
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "language" : "fr",
+    "region" : "FR"
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Automattic-Tracks-iOS.xcodeproj",
+        "identifier" : "93B5C7B31CE25D40002820B3",
+        "name" : "Automattic-Tracks-iOSTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/TracksDemo/Podfile.lock
+++ b/TracksDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Automattic-Tracks-iOS (0.8.0):
+  - Automattic-Tracks-iOS (0.8.2):
     - CocoaLumberjack (~> 3)
     - Reachability (~> 3)
     - Sentry (~> 6)
@@ -34,7 +34,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Automattic-Tracks-iOS: 1f68ebf14cc9607c65685f46b58e81532932bf48
+  Automattic-Tracks-iOS: f706ecd3fe22f6cfc6904bf65c5675874c1bceff
   CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: 3a6c3aeb258b297a4be08d8960955ecc722331f3


### PR DESCRIPTION
Currently errors logged using `logError` send localized strings to Sentry, which causes a lot of noise. 

This change will always send the English description instead.

**To Test:**
- Run the demo app, and choose "Send Test Error". The error will show up in Sentry untranslated.