### PR TITLE
[Tooling] Standardize podspec format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,28 @@ jobs:
                        -scheme 'Automattic-Tracks-OSX' \
                        -destination 'platform=OS X,arch=x86_64' \
                        test  | tee logs/build-and-test.log | xcpretty -r junit
+  CheckVersionConsistency:
+    docker:
+      - image: cimg/base:2020.01
+    steps:
+      - checkout
+      - run:
+          name: Check pod version consistency
+          command: |
+            SRC_FILE=Automattic-Tracks-iOS/TracksConstants.m
+            PODSPEC_FILE=Automattic-Tracks-iOS.podspec
 
+            SOURCE_VERS=$(sed -n s/'^.* TracksLibraryVersion = @"\(.*\)";.*$'/'\1'/p $SRC_FILE)
+            POD_VERS=$(sed -n s/'^ *s.version *= \([^ ]*\).*$'/'\1'/p $PODSPEC_FILE | tr -d \'\")
+            
+            echo Version found in $SRC_FILE: $SOURCE_VERS
+            echo Version found in $PODSPEC_FILE: $POD_VERS
+            if [ "$SOURCE_VERS" = "$POD_VERS" ]; then
+              echo "Version values match :)"
+            else
+              echo "Version values differ! Please fix by making sure the 2 files have matching values for the version."
+              exit 1
+            fi
 workflows:
   test_and_validate:
     jobs:
@@ -67,5 +88,7 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
+      - CheckVersionConsistency:
+          name: "Validate Version Values Consistency"
       - TestMacOS:
           name: "Test macOS"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
               echo "Version values differ! Please fix by making sure the 2 files have matching values for the version."
               exit 1
             fi
+
 workflows:
   test_and_validate:
     jobs:

--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = File.read("Automattic-Tracks-iOS/TracksConstants.m").split("const TracksLibraryVersion = @\"").last.split("\"").first
+  s.version       = '0.8.3'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -1,36 +1,42 @@
-Pod::Spec.new do |spec|
-  spec.name         = 'Automattic-Tracks-iOS'
-  spec.version      = File.read("Automattic-Tracks-iOS/TracksConstants.m").split("const TracksLibraryVersion = @\"").last.split("\"").first
-  spec.license      = { :type => 'GPLv2' }
-  spec.homepage     = 'https://github.com/automattic/automattic-tracks-ios'
-  spec.authors      = { 'Automattic' => 'mobile@automattic.com' }
-  spec.summary      = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
-  spec.source       = { :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => spec.version.to_s }
-  spec.swift_version = '5.0'
+Pod::Spec.new do |s|
+  s.name          = 'Automattic-Tracks-iOS'
+  s.version       = File.read("Automattic-Tracks-iOS/TracksConstants.m").split("const TracksLibraryVersion = @\"").last.split("\"").first
 
-  spec.ios.source_files = 'Automattic-Tracks-iOS/**/*.{h,m,swift}'
-  spec.ios.exclude_files = 'Automattic-Tracks-OSX/Automattic_Tracks_OSX.h'
+  s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
+  s.description   = <<-DESC
+                    This framework provides an abstract layer on our Automattic Tracks internal analytics service,
+                    and allows to easily send events to Tracks to monitor our app's activity and flows.
+                  DESC
 
-  spec.osx.source_files = 'Automattic-Tracks-iOS/**/*.{h,m,swift}'
-  spec.osx.exclude_files = ['Automattic-Tracks-iOS/Automattic-Tracks-iOS.h', 'Automattic-Tracks-iOS/ABTesting/*']
+  s.homepage      = 'https://github.com/Automattic/Automattic-Tracks-iOS'
+  s.license       = { :type => 'GPLv2', :file => 'LICENSE' }
+  s.author        = { 'Automattic' => 'mobile@automattic.com' }
+  s.social_media_url = 'https://twitter.com/automattic'
 
-  spec.private_header_files = 'Automattic-Tracks-iOS/Internal Logging/TracksLoggingPrivate.h'
-  spec.resource_bundle = { 'DataModel' => ['Automattic-Tracks-iOS/**/*.xcdatamodeld'] }
+  s.ios.deployment_target = '12.0'
+  s.osx.deployment_target = '10.12'
+  s.swift_version = '5.0'
 
-  spec.framework        = 'CoreData'
-  spec.ios.framework    = 'UIKit'
-  spec.ios.framework    = 'CoreTelephony'
-  spec.osx.framework    = 'AppKit'
+  s.source        = { :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => s.version.to_s }
+  s.ios.source_files = 'Automattic-Tracks-iOS/**/*.{h,m,swift}'
+  s.ios.exclude_files = 'Automattic-Tracks-OSX/Automattic_Tracks_OSX.h'
+  s.osx.source_files = 'Automattic-Tracks-iOS/**/*.{h,m,swift}'
+  s.osx.exclude_files = ['Automattic-Tracks-iOS/Automattic-Tracks-iOS.h', 'Automattic-Tracks-iOS/ABTesting/*']
 
-  spec.ios.deployment_target  = '12.0'
-  spec.osx.deployment_target  = '10.12'
+  s.private_header_files = 'Automattic-Tracks-iOS/Internal Logging/TracksLoggingPrivate.h'
+  s.resource_bundle = { 'DataModel' => ['Automattic-Tracks-iOS/**/*.xcdatamodeld'] }
 
-  spec.header_dir = 'AutomatticTracks'
-  spec.module_name = 'AutomatticTracks'
+  s.framework        = 'CoreData'
+  s.ios.framework    = 'UIKit'
+  s.ios.framework    = 'CoreTelephony'
+  s.osx.framework    = 'AppKit'
 
-  spec.ios.dependency 'UIDeviceIdentifier', '~> 1'
-  spec.dependency 'CocoaLumberjack', '~> 3'
-  spec.dependency 'Reachability', '~> 3'
-  spec.dependency 'Sentry', '~> 6'
-  spec.dependency 'Sodium', '>= 0.9.1'
+  s.header_dir = 'AutomatticTracks'
+  s.module_name = 'AutomatticTracks'
+
+  s.ios.dependency 'UIDeviceIdentifier', '~> 1'
+  s.dependency 'CocoaLumberjack', '~> 3'
+  s.dependency 'Reachability', '~> 3'
+  s.dependency 'Sentry', '~> 6'
+  s.dependency 'Sodium', '>= 0.9.1'
 end

--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '1.2.3'
+  s.version       = '0.8.3'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '0.8.3'
+  s.version       = '1.2.3'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/TracksDemo/Podfile.lock
+++ b/TracksDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Automattic-Tracks-iOS (0.8.2):
+  - Automattic-Tracks-iOS (0.8.3):
     - CocoaLumberjack (~> 3)
     - Reachability (~> 3)
     - Sentry (~> 6)
@@ -34,7 +34,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Automattic-Tracks-iOS: f706ecd3fe22f6cfc6904bf65c5675874c1bceff
+  Automattic-Tracks-iOS: d2b08d823912bfd8be65b5b8f932f023d0478c64
   CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: 3a6c3aeb258b297a4be08d8960955ecc722331f3


### PR DESCRIPTION
As part of paaHJt-Vl-p2, this simply standardize the podspec file so that all our pods use a similar format and structure, with similar keys and common values.

See wordpress-mobile/WordPressAuthenticator-iOS#582 for the rules I decided to follow on the format and content standardization.