### PR TITLE
ExPlat: fix refreshIfNeeded

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '0.8.3'
+  s.version       = '0.8.4'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/Automattic-Tracks-iOS/ABTesting/ExPlat.swift
+++ b/Automattic-Tracks-iOS/ABTesting/ExPlat.swift
@@ -41,7 +41,7 @@ import Cocoa
     /// Only refresh if the TTL has expired
     ///
     public func refreshIfNeeded(completion: (() -> Void)? = nil) {
-        guard ttl > 0 else {
+        guard ttl <= 0 else {
             completion?()
             return
         }

--- a/Automattic-Tracks-iOS/TracksConstants.m
+++ b/Automattic-Tracks-iOS/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.8.3";
+NSString *const TracksLibraryVersion = @"0.8.4";


### PR DESCRIPTION
This PR fixes a silly issue (yes, I know, shame on me) in `refreshIfNeeded`:

* It should refresh *if* the TTL has expired (< 0), not the other way around

I added a unit test to avoid regression and to ensure that the issue was properly fixed.