### PR TITLE
Crash logging: Add hybrid SDK helpers to allow better stack traces for other platforms

### DIFF
--- a/Automattic-Tracks-iOS/Crash Logging/CrashLogging.swift
+++ b/Automattic-Tracks-iOS/Crash Logging/CrashLogging.swift
@@ -50,19 +50,27 @@ public class CrashLogging {
         return self
     }
 
+    public func shouldSendEvent() -> Bool {
+        #if DEBUG
+        return UserDefaults.standard.bool(forKey: "force-crash-logging")
+        #else
+        return !dataProvider.userHasOptedOut
+        #endif
+    }
+    
     func beforeSend(event: Sentry.Event?) -> Sentry.Event? {
 
         DDLogDebug("📜 Firing `beforeSend`")
 
         #if DEBUG
         DDLogDebug("📜 This is a debug build")
-        let shouldSendEvent = UserDefaults.standard.bool(forKey: "force-crash-logging")
-        #else
-        let shouldSendEvent = !dataProvider.userHasOptedOut
         #endif
 
         /// If we shouldn't send the event we have nothing else to do here
-        guard let event = event, shouldSendEvent else {
+        if !shouldSendEvent() {
+            return nil
+        }
+        guard let event = event else {
             return nil
         }
 

--- a/Automattic-Tracks-iOS/Crash Logging/CrashLogging.swift
+++ b/Automattic-Tracks-iOS/Crash Logging/CrashLogging.swift
@@ -337,19 +337,19 @@ extension CrashLogging {
     public func logEnvelope(_ envelopeDict: [String: Any]) {
         if JSONSerialization.isValidJSONObject(envelopeDict) {
             guard let headerDict = envelopeDict["header"] as? [String: Any] else {
-                DDLogError("⛔️ Unable to send JS exception to Sentry – header is not defined in the envelope.")
+                DDLogError("⛔️ Unable to send envelope to Sentry – header is not defined in the envelope.")
                 return
             }
             guard let headerEventId = headerDict["event_id"] as? String else {
-                DDLogError("⛔️ Unable to send JS exception to Sentry – event_id is not defined in the envelope.")
+                DDLogError("⛔️ Unable to send envelope to Sentry – event id is not defined in the envelope header.")
                 return
             }
             guard let payloadDict = envelopeDict["payload"] as? [String: Any] else {
-                DDLogError("⛔️ Unable to send JS exception to Sentry – payload is not defined in the envelope.")
+                DDLogError("⛔️ Unable to send envelope to Sentry – payload is not defined in the envelope.")
                 return
             }
             guard let eventLevel = payloadDict["level"] as? String else {
-                DDLogError("⛔️ Unable to send JS exception to Sentry – level is not defined in the envelope.")
+                DDLogError("⛔️ Unable to send envelope to Sentry – level is not defined in the envelope payload.")
                 return
             }
 
@@ -359,7 +359,7 @@ extension CrashLogging {
             let envelopeHeader = SentryEnvelopeHeader.init(id: eventId, andSdkInfo: sdkInfo)
 
             guard let envelopeItemData = try? JSONSerialization.data(withJSONObject: payloadDict) else {
-                DDLogError("⛔️ Unable to send JS exception to Sentry – payload could not be serialized.")
+                DDLogError("⛔️ Unable to send envelope to Sentry – payload could not be serialized.")
                 return
             }
 
@@ -379,7 +379,7 @@ extension CrashLogging {
             }
             #endif
         } else {
-            DDLogError("⛔️ Unable to send JS exception to Sentry – envelope is not a valid JSON object.")
+            DDLogError("⛔️ Unable to send envelope to Sentry – envelope is not a valid JSON object.")
         }
     }
 }


### PR DESCRIPTION
This PR adds helpers that will allow us to improve the stack traces that we get when an exception is caused by hybrid SDKs, like React native for the Gutenberg editor.

**Related PRs:**
`WordPress-iOS`PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16700
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3629
`gutenberg` PR: https://github.com/WordPress/gutenberg/pull/32768