### PR TITLE
Update `UIDeviceIdentifiers` dependency to version 2.0.0

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   s.header_dir = 'AutomatticTracks'
   s.module_name = 'AutomatticTracks'
 
-  s.ios.dependency 'UIDeviceIdentifier', '~> 1'
+  s.ios.dependency 'UIDeviceIdentifier', '~> 2.0'
   s.dependency 'Sentry', '~> 6'
   s.dependency 'Sodium', '>= 0.9.1'
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/squarefrog/UIDeviceIdentifier",
         "state": {
           "branch": null,
-          "revision": "67b7d4d290a5b8e983f4cc9e4826217bc66899b5",
-          "version": "1.7.0"
+          "revision": "6a1f66c676f327e6741066147468928555f5d6af",
+          "version": "2.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "6.0.0"),
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.0.0"),
-        .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "1.7.0"),
+        .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.0.0"),
         .package(name: "OCMock", url: "https://github.com/erikdoe/ocmock", .branch("master")),
         .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium", from: "0.9.1"),
     ],

--- a/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/squarefrog/UIDeviceIdentifier",
         "state": {
           "branch": null,
-          "revision": "67b7d4d290a5b8e983f4cc9e4826217bc66899b5",
-          "version": "1.7.0"
+          "revision": "6a1f66c676f327e6741066147468928555f5d6af",
+          "version": "2.0.0"
         }
       }
     ]


### PR DESCRIPTION
The major version breaking change is due to the library explicitly supporting iOS 9.0 and above, thus dropping support for all prior versions. That doesn't affect us, of course, because we are targeting way above 9.0 already.

See https://github.com/squarefrog/UIDeviceIdentifier/issues/47#issuecomment-998592243

I think we ought to upgrade to 2.0.0 to avoid `pod update` not fetching newest versions because it would stop to the latest 1.x release of the library.

### Testing Details

There are only new methods and new devices between 2.0.0 and the previous version, 1.1.4: https://github.com/squarefrog/UIDeviceIdentifier/compare/1.1.4...2.0.0 If CI is green, we can merge this.