### PR TITLE
Bump version from 0.10.1 to 0.11.0

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '0.10.1'
+  s.version       = '0.11.0'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.10.1";
+NSString *const TracksLibraryVersion = @"0.11.0";


### PR DESCRIPTION
Bumped the minor version because of the breaking change in the UIDeviceIdentifier dependency bump. Since we're not at a stable release (1.0.0), there's no need to bump the major version value at this time.

This version bump PR is here to leave a breadcrumb in the release process. I will be admin-merge it and deploy the new version as soon as CI is green. I'll submit a merge PR against `trunk` for review later on.