### PR TITLE
Always throw an exception for a core data error that prevents us from initializing Tracks.

### DIFF
--- a/Sources/Model/ObjC/Common/Core Data/TracksContextManager.m
+++ b/Sources/Model/ObjC/Common/Core Data/TracksContextManager.m
@@ -47,21 +47,17 @@ NSString *const TracksPersistentStoreException      = @"TracksPersistentStoreExc
     NSURL *storeURL = [self storeURL];
     NSError *error = nil;
     if (![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
-
+        
         // Delete the store and try again
         [[NSFileManager defaultManager] removeItemAtPath:storeURL.path error:nil];
         if (![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
             // Replace this with code to handle the error appropriately.
             // abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
             TracksLogError(@"Unresolved error %@, %@", error, [error userInfo]);
-
-            if (self.shouldThrowUponFatalCondition) {
-                @throw [NSException exceptionWithName:TracksPersistentStoreException
-                                               reason:[NSString stringWithFormat:@"Error initializing Tracks: %@", error]
-                                             userInfo:error.userInfo];
-            } else {
-                abort();
-            }
+            
+            @throw [NSException exceptionWithName:TracksPersistentStoreException
+                                           reason:[NSString stringWithFormat:@"Error initializing Tracks: %@", error]
+                                         userInfo:error.userInfo];
         }
     }
     
@@ -88,28 +84,19 @@ NSString *const TracksPersistentStoreException      = @"TracksPersistentStoreExc
                              withIntermediateDirectories:true
                                               attributes:nil
                                                    error:&error];
-
+    
     // It seems safe not to handle this error because Application Support should always be
     // available and one should always be able to create a folder in it
     if (error != nil) {
         TracksLogError(@"Failed to create folder for %@ in Application Support: %@, %@", bundleIdentifier, error, [error userInfo]);
-
-        if (self.shouldThrowUponFatalCondition) {
-            @throw [NSException exceptionWithName:TracksApplicationSupportException
-                                           reason:[NSString stringWithFormat:@"Error creating the ApplicationSupport Folder: %@", error]
-                                         userInfo:error.userInfo];
-        } else {
-            abort();
-        }
+        
+        @throw [NSException exceptionWithName:TracksApplicationSupportException
+                                       reason:[NSString stringWithFormat:@"Error creating the ApplicationSupport Folder: %@", error]
+                                     userInfo:error.userInfo];
+        
     }
-
+    
     return folder;
-}
-
-- (BOOL)shouldThrowUponFatalCondition {
-    // We consider it safe to Throw (whenever a Fatal Condition arises) whenever there is no global
-    // NSException handler set
-    return NSGetUncaughtExceptionHandler() == nil;
 }
 
 // Application Support contains "the files that your app creates and manages on behalf of the user


### PR DESCRIPTION
This PR throws an exception with error information for core data errors that prevent us from initializing tracks, instead of using an abort().

On our first attempt to throw this exception, so that we could get more information in Sentry in the Day One iOS project, @jleandroperez attempted to only throw the exception if NSGetUncaughtExceptionHandler() was nil, hoping to cause minimal changes for other apps that may have employed an exception handler. 

However, it appears that at least in the case of the Day One app, NSGetUncaughtExceptionHandler is not nil when we expect it to be, and thus, abort() is called instead of throwing an exception with a more detailed error message. 

I suspect this may be related to when Sentry is used. I cannot confirm this in XCode builds, but given that we are seeing the abort() line in Sentry still being called, this is what we expect is happening. 

In Day One, in Sentry, we are seeing the abort() line still called here, and thus we are unable to get information about why the data model is not able to set up correctly. We are seeing a large number of crashes (likely happening when the app is in the background) that appear to be caused by this line, so we would like to figure out why this is happening. 

