### PR TITLE
Ensure network monitor path update handler is called on start

### DIFF
--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -320,7 +320,7 @@ NSString *const USER_ID_ANON = @"anonId";
     self.networkMonitor = nw_path_monitor_create();
 
     __weak typeof(self) weakSelf = self;
-    nw_path_monitor_set_update_handler(self.networkMonitor, ^(nw_path_t  _Nonnull path) {
+    nw_path_monitor_set_update_handler(self.networkMonitor, ^(nw_path_t _Nonnull path) {
         [weakSelf networkPathChanged:path];
     });
     nw_path_monitor_start(self.networkMonitor);

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -327,8 +327,8 @@ NSString *const USER_ID_ANON = @"anonId";
     // Without one, the update handler doesn't get called when the monitor starts.
     dispatch_queue_attr_t attrs = dispatch_queue_attr_make_with_qos_class(
                                                                           DISPATCH_QUEUE_SERIAL,
-                                                                          QOS_CLASS_UTILITY,
-                                                                          DISPATCH_QUEUE_PRIORITY_DEFAULT
+                                                                          0,
+                                                                          0 // The relative priority within the QOS class. Can range from 0 to -15.
                                                                           );
     self.networkMonitorQueue = dispatch_queue_create("com.automattic.tracks.network.monitor", attrs);
     nw_path_monitor_set_queue(self.networkMonitor, self.networkMonitorQueue);

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -317,8 +317,9 @@ NSString *const USER_ID_ANON = @"anonId";
         return;
     }
 
-    __weak typeof(self) weakSelf = self;
     self.networkMonitor = nw_path_monitor_create();
+
+    __weak typeof(self) weakSelf = self;
     nw_path_monitor_set_update_handler(self.networkMonitor, ^(nw_path_t  _Nonnull path) {
         [weakSelf networkPathChanged:path];
     });

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -319,10 +319,10 @@ NSString *const USER_ID_ANON = @"anonId";
 
     __weak typeof(self) weakSelf = self;
     self.networkMonitor = nw_path_monitor_create();
-    nw_path_monitor_set_update_handler(_networkMonitor, ^(nw_path_t  _Nonnull path) {
+    nw_path_monitor_set_update_handler(self.networkMonitor, ^(nw_path_t  _Nonnull path) {
         [weakSelf networkPathChanged:path];
     });
-    nw_path_monitor_start(_networkMonitor);
+    nw_path_monitor_start(self.networkMonitor);
 }
 
 - (void)stopNetworkMonitor {


### PR DESCRIPTION
Earlier today, @yaelirub reported an unusual spike in events logged with the device offline in WordPress iOS starting from 19.2. 

Together with @twstokes, the tracked it to the Tracks [update to version 0.11.0](https://github.com/wordpress-mobile/WordPress-iOS/commit/ddaa3f62f0f887b8b64497c6281f013112c2ae5e) and the new network reachability logic from #186. Tanner noticed that, at launch, the network path was `nil`, resulting in [this branch](https://github.com/Automattic/Automattic-Tracks-iOS/blob/7fc4afe72cd1539575135891d90bef26ee32106c/Sources/Event%20Logging/TracksService.m#L264-L265) of the network properties logging conditional running. 

I experienced the same behavior when running the TracksDemo app from this repo ([microapps](https://increment.com/mobile/microapps-architecture/) FTW!).

The behavior I experienced was that the block meant to receive network path updates was not called when the monitor started, even though that's the expectation set by the documentation.

I did some googling but nobody reported the issue. I stumbled onto [this post](https://msolarana.netlify.app/2018/08/04/monitoring-network-changes/) by @madsolar8582 that also explicitly sets a queue on which to dispatch the update block execution. I tried it out and it did the trick 🎉 

**To test**

On `trunk`, put a breakpoint in the update block: https://github.com/Automattic/Automattic-Tracks-iOS/blob/7fc4afe72cd1539575135891d90bef26ee32106c/Sources/Event%20Logging/TracksService.m#L323

Notice that it's not hit on start, but it is if you change you network interface, for example by turning the Wi-Fi on.

Repeat on this branch and notice that the block is called when the demo app starts (fix) and also when the network changes (no regressions).

Alternatively, use `updateDeviceInformationFromReachability` as the inspection point for the breakpoint. On `trunk` here: [updateDeviceInformationFromReachability](https://github.com/Automattic/Automattic-Tracks-iOS/blob/7fc4afe72cd1539575135891d90bef26ee32106c/Sources/Event%20Logging/TracksService.m#L323). If you do that, be mindful that it gets called as part of `TracksService` init, and will have `self.networkPath` `nil` there because the monitoring hasn't been setup yet.