### PR TITLE
Make Mac OS version parsable 

### DIFF
--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.m
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.m
@@ -110,9 +110,9 @@
     return [[UIDevice currentDevice] systemVersion];
 #else   // Mac
     NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
-    NSInteger *major = version.majorVersion;
-    NSInteger *minor = version.minorVersion;
-    NSInteger *patch = version.patchVersion;
+    NSInteger major = version.majorVersion;
+    NSInteger minor = version.minorVersion;
+    NSInteger patch = version.patchVersion;
     return [NSString stringWithFormat: @"%ld.%ld.%ld", (long)major, (long)minor, (long)patch];
 #endif
 }

--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.m
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.m
@@ -109,7 +109,11 @@
 #if TARGET_OS_IPHONE
     return [[UIDevice currentDevice] systemVersion];
 #else   // Mac
-    return [[NSProcessInfo processInfo] operatingSystemVersionString];
+    NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
+    NSInteger *major = version.majorVersion;
+    NSInteger *minor = version.minorVersion;
+    NSInteger *patch = version.patchVersion;
+    return [NSString stringWithFormat: @"%ld.%ld.%ld", (long)major, (long)minor, (long)patch];
 #endif
 }
 


### PR DESCRIPTION
Previously we were recording the [[NSProcessInfo processInfo] operatingSystemVersionString] as the os version, but this is a localized string that is not fit for parsing. (It reads like `Version 12.2.1 (Build 21D62)`, where version and build are localized).

Instead, use [[NSProcessInfo processInfo] operatingSystemVersion], and record our own non-localized string instead. Will record version like `12.2.1`. 

Fixes https://github.com/bloom/DayOne-iOS/issues/18755

I tested this by by putting a breakpoint in TracksSevice, line 146, running TracksDemo Mac on my Mac, and then printing out self.deviceInformation.version and verifying that it was the same as my Mac OS version. 

If you want to test like this you'll need to add the Sentry DSN in Secrets.sentryDSN. You can find this by searching for `macOSSentryDSN` in the Day One project.