### PR TITLE
Add Buildkite Test Analytics support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -38,6 +38,15 @@
         }
       },
       {
+        "package": "BuildkiteTestCollector",
+        "repositoryURL": "https://github.com/buildkite/test-collector-swift",
+        "state": {
+          "branch": null,
+          "revision": "a5ec5f4379cdc28d1651d49e30afecf795e18dd1",
+          "version": "0.1.1"
+        }
+      },
+      {
         "package": "UIDeviceIdentifier",
         "repositoryURL": "https://github.com/squarefrog/UIDeviceIdentifier",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "AutomatticTracksiOS",
-    platforms: [.macOS(.v10_14), .iOS(.v12)],
+    platforms: [.macOS(.v10_14), .iOS(.v13)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,7 @@ let package = Package(
         .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.0.0"),
         .package(name: "OCMock", url: "https://github.com/erikdoe/ocmock", .branch("master")),
         .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium", from: "0.9.1"),
+        .package(name: "BuildkiteTestCollector", url: "https://github.com/buildkite/test-collector-swift", from: "0.1.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -150,23 +151,28 @@ let package = Package(
                 "AutomatticTracks",
                 "AutomatticTracksEvents",
                 "AutomatticTracksModel",
+                "BuildkiteTestCollector",
                 .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
             ],
             path: "Tests",
             exclude: ["Tests/ObjC"],
-            resources: [.process("Mock Data")]),
+            resources: [.process("Mock Data")]
+        ),
 
-            .testTarget(
-                name: "AutomatticTracksTestsObjC",
-                dependencies: ["AutomatticTracksEvents",
-                               "OCMock"
-                              ],
-                path: "Tests/Tests/ObjC"),
+        .testTarget(
+            name: "AutomatticTracksTestsObjC",
+            dependencies: [
+                "AutomatticTracksEvents",
+                "BuildkiteTestCollector",
+                "OCMock",
+            ],
+            path: "Tests/Tests/ObjC"
+        ),
 
-            .target(
-                name: "_WorkaroundSPM",
-                dependencies: ["Sodium"],
-                path: "Sources/Workaround-SPM")
-
+        .target(
+            name: "_WorkaroundSPM",
+            dependencies: ["Sodium"],
+            path: "Sources/Workaround-SPM"
+        )
     ]
 )

--- a/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -56,6 +56,15 @@
         }
       },
       {
+        "package": "BuildkiteTestCollector",
+        "repositoryURL": "https://github.com/buildkite/test-collector-swift",
+        "state": {
+          "branch": null,
+          "revision": "a5ec5f4379cdc28d1651d49e30afecf795e18dd1",
+          "version": "0.1.1"
+        }
+      },
+      {
         "package": "UIDeviceIdentifier",
         "repositoryURL": "https://github.com/squarefrog/UIDeviceIdentifier",
         "state": {


### PR DESCRIPTION
Integrating Buildkite Test Analytics in the pipeline is a matter of:

1. Exposing the Buildkite-generated `BUILDKITE_ANALYTICS_TOKEN` to the agent, which I did through our internal tooling for managing secrets
2. Adding the [BuildkiteTestCollector](https://github.com/buildkite/test-collector-swift/) package as a dependency of the test s target

You can see the result in the brand new [Tests Analytics page](https://buildkite.com/organizations/automattic/analytics/suites/tracks-apple?branch=all+branches) for this project

<img width="1497" alt="image" src="https://user-images.githubusercontent.com/1218433/173759382-264013cc-461b-497e-9bbd-c2a1e9577dc1.png">

---

**Next steps:** This was a learning experiment, the big test will be to enable test analytics in WordPress iOS. ✨ 