### PR TITLE
Update Swift tools version from 5.3 to 5.5

### DIFF
--- a/.buildkite/check-version-consistency.sh
+++ b/.buildkite/check-version-consistency.sh
@@ -3,6 +3,9 @@
 SRC_FILE=Sources/Model/ObjC/Constants/TracksConstants.m
 PODSPEC_FILE=Automattic-Tracks-iOS.podspec
 
+# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
+gem install bundler
+
 SOURCE_VERS=$(sed -n s/'^.* TracksLibraryVersion = @"\(.*\)";.*$'/'\1'/p $SRC_FILE)
 POD_VERS=$(sed -n s/'^ *s.version *= \([^ ]*\).*$'/'\1'/p $PODSPEC_FILE | tr -d \'\")
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ common_params:
   - &bash_cache automattic/bash-cache#v1.5.0: ~
   # Common environment values to use with the `env` key.
   env: &common_env
-    IMAGE_ID: xcode-12.5.1
+    IMAGE_ID: xcode-13.4.1
 
 # This is the default pipeline – it will build and test the app
 steps:
@@ -14,6 +14,9 @@ steps:
   - label: "🧪 Build and Test iOS"
     key: "test_ios"
     command: |
+      # Workaround for https://github.com/Automattic/buildkite-ci/issues/79
+      gem install bundler
+
       # Build and test the pod twice if needed. This is necessary under Xcode 12 to avoid an error
       # that occurs the first time after cleaning if one of your dependences uses a binary framework
       # See https://bugs.swift.org/browse/SR-13803
@@ -29,6 +32,9 @@ steps:
   - label: "🧪 Build and Test macOS"
     key: "test_macos"
     command: |
+      # Workaround for https://github.com/Automattic/buildkite-ci/issues/79
+      gem install bundler
+
       # Build and test the pod twice if needed. This is necessary under Xcode 12 to avoid an error
       # that occurs the first time after cleaning if one of your dependences uses a binary framework
       # See https://bugs.swift.org/browse/SR-13803
@@ -43,7 +49,11 @@ steps:
   #################
   - label: "🔬 Validating Podspec"
     key: "validate"
-    command: "validate_podspec"
+    command: |
+      # Workaround for https://github.com/Automattic/buildkite-ci/issues/79
+      gem install bundler
+
+      validate_podspec
     env: *common_env
     plugins: *common_plugins
     artifact_paths: ".build/logs/*.log"
@@ -62,7 +72,11 @@ steps:
   #################
   - label: "🧹 Lint"
     key: "lint"
-    command: "lint_pod"
+    command: |
+      # Workaround for https://github.com/Automattic/buildkite-ci/issues/79
+      gem install bundler
+
+      lint_pod
     env: *common_env
     plugins: *common_plugins
 

--- a/.buildkite/publish-pod.sh
+++ b/.buildkite/publish-pod.sh
@@ -4,6 +4,10 @@ PODSPEC_PATH="Automattic-Tracks-iOS.podspec"
 SLACK_WEBHOOK=$PODS_SLACK_WEBHOOK
 
 echo "--- :rubygems: Setting up Gems"
+
+# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
+gem install bundler
+
 install_gems
 
 echo "--- :cocoapods: Publishing Pod to CocoaPods CDN"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Notice that this introduces an error when running `swift test`:

```
$ swift test

Building for debugging...
/Users/gio/Developer/a8c/tracks-apple-pod/Sources/Model/ObjC/Common/Core Data/TracksContextManager.m:24:24: error: use of undeclared identifier 'SWIFTPM_MODULE_BUNDLE'
    NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
                       ^
1 error generated.
[0/6] Compiling TracksContextManager.m
error: fatalError
```

This is a known Swift Package Manager issue. See:

- https://github.com/apple/swift-package-manager/issues/4500
- https://forums.swift.org/t/5-3-resources-support-not-working-on-with-swift-test/40381

However, `bundle exec fastlane test`, which uses `xcodebuild` under the hood, works.

Given our workflow is based on Xcode locally and Fastlane in CI, the regression seems acceptable.

The reason I'm keen to upgrade to 5.5 is that it's the required tooling version to integrate Buildkite's Test Analytics. See
https://github.com/buildkite/test-collector-swift/blob/v0.1.0/Package.swift#L1