### PR TITLE
DRY string for `unavailable` `UIApplication.State`

### DIFF
--- a/Sources/Remote Logging/Crash Logging/ApplicationFacade.swift
+++ b/Sources/Remote Logging/Crash Logging/ApplicationFacade.swift
@@ -25,11 +25,11 @@ final class ApplicationFacade {
         #if os(iOS)
         guard Thread.isMainThread else {
             // UIApplication.applicationState can only be accessed from the main thread.
-            return "unavailable"
+            return UIApplication.State.unavailable
         }
 
         return (UIApplication.sharedIfAvailable()?.applicationState.descriptionForEventTag
-                ?? "unavailable")
+                ?? UIApplication.State.unavailable)
 
         #else
 
@@ -59,6 +59,8 @@ private extension UIApplication.State {
             return "unknown"
         }
     }
+
+    static var unavailable: String { "unavailable" }
 }
 
 #endif


### PR DESCRIPTION
I've been dipping in and out of the code while trying to understand how to migrate to Sentry version 7.x. As a result, I took a minute to extract a duplicated string into a single place.