### PR TITLE
Add an anonymous ID to configure ExPlat for authenticated users

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '0.11.1'
+  s.version       = '0.12.0-beta.1'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '0.12.0-beta.1'
+  s.version       = '0.12.0-beta.2'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/Sources/Event Logging/TracksService.h
+++ b/Sources/Event Logging/TracksService.h
@@ -28,6 +28,8 @@ extern NSString *const TrackServiceDidSendQueuedEventsNotification;
 
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent;
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent;
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID anonymousID:(NSString *)anonymousID skipAliasEventCreation:(BOOL)skipEvent;
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID anonymousID:(NSString *)anonymousID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent;
 - (void)switchToAnonymousUserWithAnonymousID:(NSString *)anonymousID;
 
 - (void)trackEventName:(NSString *)eventName;

--- a/Sources/Event Logging/TracksService.h
+++ b/Sources/Event Logging/TracksService.h
@@ -28,7 +28,6 @@ extern NSString *const TrackServiceDidSendQueuedEventsNotification;
 
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent;
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent;
-- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID anonymousID:(NSString *)anonymousID skipAliasEventCreation:(BOOL)skipEvent;
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID anonymousID:(NSString *)anonymousID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent;
 - (void)switchToAnonymousUserWithAnonymousID:(NSString *)anonymousID;
 

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -202,16 +202,6 @@ NSString *const USER_ID_ANON = @"anonId";
 
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent
 {
-    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:nil skipAliasEventCreation:skipEvent];
-}
-
-- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
-{
-    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:nil wpComToken:token skipAliasEventCreation:skipEvent];
-}
-
-- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID anonymousID:(NSString *)anonymousID skipAliasEventCreation:(BOOL)skipEvent
-{
     NSParameterAssert(username.length != 0 || userID.length != 0);
     
     NSString *previousUserID = self.userID;
@@ -225,9 +215,14 @@ NSString *const USER_ID_ANON = @"anonId";
     }
 }
 
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
+{
+    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:nil wpComToken:token skipAliasEventCreation:skipEvent];
+}
+
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID anonymousID:(NSString *)anonymousID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
 {
-    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:anonymousID skipAliasEventCreation:skipEvent];
+    [self switchToAuthenticatedUserWithUsername:username userID:userID skipAliasEventCreation:skipEvent];
 
     self.token = token;
 

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -202,6 +202,11 @@ NSString *const USER_ID_ANON = @"anonId";
 
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent
 {
+    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:nil skipAliasEventCreation:skipEvent];
+}
+
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID anonymousID:(NSString *)anonymousID skipAliasEventCreation:(BOOL)skipEvent
+{
     NSParameterAssert(username.length != 0 || userID.length != 0);
     
     NSString *previousUserID = self.userID;
@@ -217,12 +222,17 @@ NSString *const USER_ID_ANON = @"anonId";
 
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
 {
-    [self switchToAuthenticatedUserWithUsername:username userID:userID skipAliasEventCreation:skipEvent];
+    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:nil wpComToken:token skipAliasEventCreation:skipEvent];
+}
+
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID anonymousID:(NSString *)anonymousID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
+{
+    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID: anonymousID skipAliasEventCreation:skipEvent];
 
     self.token = token;
 
     #if TARGET_OS_IPHONE
-    [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:token userAgent:self.userAgent anonId:nil];
+    [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:token userAgent:self.userAgent anonId:anonymousID];
     #endif
 }
 

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -200,6 +200,16 @@ NSString *const USER_ID_ANON = @"anonId";
     [self.tracksEventService clearTracksEvents];
 }
 
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent
+{
+    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:nil skipAliasEventCreation:skipEvent];
+}
+
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
+{
+    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:nil wpComToken:token skipAliasEventCreation:skipEvent];
+}
+
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID anonymousID:(NSString *)anonymousID skipAliasEventCreation:(BOOL)skipEvent
 {
     NSParameterAssert(username.length != 0 || userID.length != 0);
@@ -224,16 +234,6 @@ NSString *const USER_ID_ANON = @"anonId";
     #if TARGET_OS_IPHONE
     [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:token userAgent:self.userAgent anonId:anonymousID];
     #endif
-}
-
-- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent
-{
-    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:nil skipAliasEventCreation:skipEvent];
-}
-
-- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
-{
-    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:nil wpComToken:token skipAliasEventCreation:skipEvent];
 }
 
 - (void)switchToAnonymousUserWithAnonymousID:(NSString *)anonymousID

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -200,11 +200,6 @@ NSString *const USER_ID_ANON = @"anonId";
     [self.tracksEventService clearTracksEvents];
 }
 
-- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent
-{
-    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:nil skipAliasEventCreation:skipEvent];
-}
-
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID anonymousID:(NSString *)anonymousID skipAliasEventCreation:(BOOL)skipEvent
 {
     NSParameterAssert(username.length != 0 || userID.length != 0);
@@ -220,20 +215,25 @@ NSString *const USER_ID_ANON = @"anonId";
     }
 }
 
-- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
-{
-    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:nil wpComToken:token skipAliasEventCreation:skipEvent];
-}
-
 - (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID anonymousID:(NSString *)anonymousID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
 {
-    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID: anonymousID skipAliasEventCreation:skipEvent];
+    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:anonymousID skipAliasEventCreation:skipEvent];
 
     self.token = token;
 
     #if TARGET_OS_IPHONE
     [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:token userAgent:self.userAgent anonId:anonymousID];
     #endif
+}
+
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID skipAliasEventCreation:(BOOL)skipEvent
+{
+    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:nil skipAliasEventCreation:skipEvent];
+}
+
+- (void)switchToAuthenticatedUserWithUsername:(NSString *)username userID:(NSString *)userID wpComToken:(NSString *)token skipAliasEventCreation:(BOOL)skipEvent
+{
+    [self switchToAuthenticatedUserWithUsername:username userID:userID anonymousID:nil wpComToken:token skipAliasEventCreation:skipEvent];
 }
 
 - (void)switchToAnonymousUserWithAnonymousID:(NSString *)anonymousID

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.12.0-beta.1";
+NSString *const TracksLibraryVersion = @"0.12.0-beta.2";

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.11.1";
+NSString *const TracksLibraryVersion = @"0.12.0-beta.1";


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

For https://github.com/woocommerce/woocommerce-ios/issues/7435
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, we passed `nil` to the anonymous ID parameter in the ExPlat configuration and we observed a high crossover rate where the same logged-in user has been assigned to more than one variation for the same A/A test. From @aaronyan's investigation pbxNRc-1S0-p2#comment-3688, the `nil` anonymous ID might have caused a high crossover rate because the anonymous ID is prioritized over the authenticated user ID when assigning a variation for an A/B experiment.

> Once assignment requests include the anon_id, then I think we should see a lot less crossovers! The anon_id will be given priority on the assignment side, so the user will be assigned the same variation that was originally given to them while they were anonymous.

Therefore, this PR added a new parameter `anonymousID` to `switchToAuthenticatedUser` where `wpComToken` is expected for ExPlat configuration. This was added as a new method so that it doesn't affect any other apps.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please check the testing steps in https://github.com/woocommerce/woocommerce-ios/pull/7574.
