### PR TITLE
Add iOS device accessibility settings to device properties.

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '0.11.1'
+  s.version       = '0.12.0-beta.1'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -401,6 +401,7 @@ NSString *const USER_ID_ANON = @"anonId";
              DeviceInfoStatusBarHeightKey : [NSNumber numberWithFloat:self.deviceInformation.statusBarHeight],
              DeviceInfoOrientation : self.deviceInformation.orientation ?: @"Unknown",
              DeviceInfoPreferredContentSizeCategory : self.deviceInformation.preferredContentSizeCategory ?: @"Unknown",
+             DeviceInfoIsAccessibilityCategory : self.deviceInformation.isAccessibilityCategory ? @"YES" : @"NO",
     };
 }
 

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -63,6 +63,7 @@ NSString *const DeviceInfoVoiceOverEnabledKey = @"device_info_voiceover_enabled"
 NSString *const DeviceInfoStatusBarHeightKey = @"device_info_status_bar_height";
 NSString *const DeviceInfoOrientation = @"device_info_orientation";
 NSString *const DeviceInfoPreferredContentSizeCategory = @"device_info_preferred_content_size_category";
+NSString *const DeviceInfoIsAccessibilityCategory = @"device_info_is_accessibility_category";
 
 NSString *const TracksEventNameKey = @"_en";
 NSString *const TracksUserAgentKey = @"_via_ua";

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -400,7 +400,8 @@ NSString *const USER_ID_ANON = @"anonId";
              DeviceInfoAppleWatchConnectedKey : self.deviceInformation.isAppleWatchConnected ? @"YES" : @"NO",
              DeviceInfoStatusBarHeightKey : [NSNumber numberWithFloat:self.deviceInformation.statusBarHeight],
              DeviceInfoOrientation : self.deviceInformation.orientation ?: @"Unknown",
-      };
+             DeviceInfoPreferredContentSizeCategory : self.deviceInformation.preferredContentSizeCategory ?: @"Unknown",
+    };
 }
 
 - (NSDictionary *)dictionaryForTracksEvent:(TracksEvent *)tracksEvent withParentCommonProperties:(NSDictionary *)parentCommonProperties

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -62,6 +62,7 @@ NSString *const DeviceInfoAppleWatchConnectedKey = @"device_info_apple_watch_con
 NSString *const DeviceInfoVoiceOverEnabledKey = @"device_info_voiceover_enabled";
 NSString *const DeviceInfoStatusBarHeightKey = @"device_info_status_bar_height";
 NSString *const DeviceInfoOrientation = @"device_info_orientation";
+NSString *const DeviceInfoPreferredContentSizeCategory = @"device_info_preferred_content_size_category";
 
 NSString *const TracksEventNameKey = @"_en";
 NSString *const TracksUserAgentKey = @"_via_ua";

--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.h
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns `true` if the preferred reading content size falls under accessibility category.
 ///
 /// - Uses `UIContentSizeCategoryIsAccessibilityCategory` method.
-/// - This will be `false`` for Mac OS.
+/// - This will be `false` for Mac OS.
 ///
 @property (nonatomic, readonly) BOOL isAccessibilityCategory;
 

--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.h
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.h
@@ -21,6 +21,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, readonly) NSString *currentNetworkOperator;
 @property (nullable, nonatomic, readonly) NSString *currentNetworkRadioType;
 @property (nonatomic, assign) BOOL isWiFiConnected;
+
+/// Preferred reading content size based on the accessibility setting of the iOS device.
+/// - This will be null for Mac OS.
+///
+@property (nullable, nonatomic, readonly) NSString *preferredContentSizeCategory;
+
 /**
  * Indicates whether the device has an Internet connection.
  */

--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.h
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL isWiFiConnected;
 
 /// Preferred reading content size based on the accessibility setting of the iOS device.
-/// - This will be null for Mac OS.
+/// - This will be NULL for Mac OS.
 ///
 @property (nullable, nonatomic, readonly) NSString *preferredContentSizeCategory;
 

--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.h
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.h
@@ -27,6 +27,13 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 @property (nullable, nonatomic, readonly) NSString *preferredContentSizeCategory;
 
+/// Returns `true` if the preferred reading content size falls under accessibility category.
+///
+/// - Uses `UIContentSizeCategoryIsAccessibilityCategory` method.
+/// - This will be `false`` for Mac OS.
+///
+@property (nonatomic, readonly) BOOL isAccessibilityCategory;
+
 /**
  * Indicates whether the device has an Internet connection.
  */

--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.m
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.m
@@ -206,6 +206,28 @@
 }
 #endif
 
+/// Preferred reading content size based on the accessibility setting of the iOS device.
+/// 
+/// - This will be null for Mac OS.
+///
+- (NSString *)preferredContentSizeCategory {
+#if TARGET_OS_IPHONE
+    if ([NSThread isMainThread]) {
+        return UIApplication.sharedIfAvailable.preferredContentSizeCategory;
+    }
+
+    __block NSString *preferredContentSizeCategory;
+
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        preferredContentSizeCategory = UIApplication.sharedIfAvailable.preferredContentSizeCategory;
+    });
+
+    return preferredContentSizeCategory;
+#else   // Mac
+    return @"Unknown";
+#endif
+}
+
 #pragma mark - App Specific Information
 
 - (NSString *)appName

--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.m
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.m
@@ -208,7 +208,7 @@
 
 /// Preferred reading content size based on the accessibility setting of the iOS device.
 /// 
-/// - This will be null for Mac OS.
+/// - This will be NULL for Mac OS.
 ///
 - (NSString *)preferredContentSizeCategory {
 #if TARGET_OS_IPHONE
@@ -224,7 +224,7 @@
 
     return preferredContentSizeCategory;
 #else   // Mac
-    return @"Unknown";
+    return NULL;
 #endif
 }
 

--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.m
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.m
@@ -228,6 +228,29 @@
 #endif
 }
 
+/// Returns `true` if the preferred reading content size falls under accessibility category.
+///
+/// - Uses `UIContentSizeCategoryIsAccessibilityCategory` method.
+/// - This will be `false`` for Mac OS.
+///
+- (BOOL)isAccessibilityCategory {
+#if TARGET_OS_IPHONE
+    __block NSString *preferredContentSizeCategory;
+
+    if ([NSThread isMainThread]) {
+        preferredContentSizeCategory = UIApplication.sharedIfAvailable.preferredContentSizeCategory;
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            preferredContentSizeCategory = UIApplication.sharedIfAvailable.preferredContentSizeCategory;
+        });
+    }
+
+    return UIContentSizeCategoryIsAccessibilityCategory(preferredContentSizeCategory);
+#else   // Mac
+    return NO;
+#endif
+}
+
 #pragma mark - App Specific Information
 
 - (NSString *)appName

--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.m
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.m
@@ -231,7 +231,7 @@
 /// Returns `true` if the preferred reading content size falls under accessibility category.
 ///
 /// - Uses `UIContentSizeCategoryIsAccessibilityCategory` method.
-/// - This will be `false`` for Mac OS.
+/// - This will be `false` for Mac OS.
 ///
 - (BOOL)isAccessibilityCategory {
 #if TARGET_OS_IPHONE

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.11.1";
+NSString *const TracksLibraryVersion = @"0.12.0-beta.1";


### PR DESCRIPTION
Related to - https://github.com/woocommerce/woocommerce-ios/pull/7576

### Changes
In order to understand the accessibility settings of our users, this PR adds the following properties to the `deviceProperties` dictionary of analytics events.
- preferred content size category to know the font size settings.
- is accessibility category boolean to know whether the font size falls under accessibility category. 

### Known issue

As this PR adds two properties to the `Transformable` `deviceInfo` (a dictionary) property of the core data model, we will face errors when trying to load stores created using previous versions of the core data model. 

This is handled [here](https://github.com/Automattic/Automattic-Tracks-iOS/blob/wcios/track-accessibility-font-setting/Sources/Model/ObjC/Common/Core%20Data/TracksContextManager.m#L51) by deleting the old store and creating a new one using the latest core data model. 

I hope that we have to use a `ValueTransformer` to deal with the `Transformable` `deviceInfo` property of the core data model. I am not sure whether this issue was ignored because,
- A change to the `Transformable` dictionary (`deviceInfo`, `customProperties`, and `userProperties`) type properties is not supposed to happen often. 
- Optimistically, the events are expected to have been already uploaded by the time the user updates the app, and the store gets deleted. 🤞 

Please correct me if I am wrong about this. 

### Testing instructions
Follow the testing instructions from https://github.com/woocommerce/woocommerce-ios/pull/7576