### PR TITLE
Update readme license to accurately reflect GPLv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ Created by initially: Aaron Douglas @astralbodies
 
 ## License
 
-Automattic-Tracks-iOS is available under the MIT license. See the [LICENSE](https://raw.githubusercontent.com/Automattic/Automattic-Tracks-iOS/trunk/LICENSE) file for more info.
+Automattic-Tracks-iOS is available under the GPLv2 license. See the [LICENSE](https://raw.githubusercontent.com/Automattic/Automattic-Tracks-iOS/trunk/LICENSE) file for more info.


### PR DESCRIPTION
Updating the Readme to correctly reflect the GPLv2 that is in [the LICENSE file](https://github.com/Automattic/Automattic-Tracks-iOS/blob/trunk/LICENSE).