### PR TITLE
Isolate call to Sentry `currentHub()`, which will be unavailable in v7.x

### DIFF
--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -233,7 +233,7 @@ public extension CrashLogging {
 
     /// A wrapper around the `SentryClient` shim – keeps each layer clean by avoiding optionality
     private func addStackTrace(to event: Event) -> Event {
-        guard let client = SentrySDK.currentHub().getClient() else {
+        guard let client = SentrySDK.currentClient() else {
             return event
         }
 

--- a/Sources/Remote Logging/Crash Logging/SentryClient+Shim.swift
+++ b/Sources/Remote Logging/Crash Logging/SentryClient+Shim.swift
@@ -31,7 +31,10 @@ extension Sentry.Client {
             return event
         }
 
-        let scope = SentrySDK.currentHub().getScope()
+        guard let scope = SentrySDK.currentScope() else {
+            return event
+        }
+
         guard let eventWithStackTrace = (self as AnyObject).prepareEvent(event, withScope: scope, alwaysAttachStacktrace: true, isCrashEvent: false)
         else {
             return event

--- a/Sources/Remote Logging/Crash Logging/SentrySDK+CurrentHub.swift
+++ b/Sources/Remote Logging/Crash Logging/SentrySDK+CurrentHub.swift
@@ -1,0 +1,36 @@
+import Sentry
+
+/// This is an extension on `SentrySDK` to hides the access to the `currentHub()` methods we use in
+/// the codebase.
+///
+/// The reason for this, other than to implement the good old Law of Demeter, is that `currentHub()`
+/// is no longer available in version 7.x. In the future we hope to be able to access this
+/// information anyway, either by Sentry helping us and introducing an alternative way to do what
+/// we need or by us doing some clever private API access. Therefore, we don't want to wholesale
+/// delete the code that used to work in version 6.x, but rather bypass it for the time being.
+extension SentrySDK {
+
+    /// Returns the current `Scope`, or a new one, for the current `SentryHub`.
+    ///
+    /// - Note: Once we'll migrate to version 7.x, this will return `.none` because `currentHub`
+    /// will no longer be available.
+    static func currentScope() -> Scope? {
+        _currentHub()?.getScope()
+    }
+
+    /// Returns the `Client` for the current `SentryHub`.
+    ///
+    /// - Note: Once we'll migrate to version 7.x, this will return `.none` because `currentHub`
+    /// will no longer be available.
+    static func currentClient() -> Sentry.Client? {
+        _currentHub()?.getClient()
+    }
+
+    /// Returns the current `SentryHub`.
+    ///
+    /// - Note: Once we'll migrate to version 7.x, this will return `.none` because `currentHub`
+    /// will no longer be available.
+    private static func _currentHub() -> SentryHub? {
+        currentHub()
+    }
+}


### PR DESCRIPTION
The idea is to bypass the code relying in `currentHub()` for the time being, while waiting for Sentry to provide us with some guidance on how to achieve the same result without `currentHub()`.

I'm not in love with this, but it will make the upgrade job more straightforward by not requiring to delete any code that we'd like to keep using in the future.