### PR TITLE
Use `key, value` instead of `$0` in Dictionary `.forEach` for readability

### DIFF
--- a/Sources/Remote Logging/Crash Logging/SentryEvent+Extensions.swift
+++ b/Sources/Remote Logging/Crash Logging/SentryEvent+Extensions.swift
@@ -18,7 +18,7 @@ extension Event {
         mutableExtra["error-code"] = error.code
         mutableExtra["error-domain"] = error.domain
 
-        error.userInfo.forEach { (key, value) in
+        error.userInfo.forEach { key, value in
             mutableExtra[key] = value
         }
 

--- a/Sources/Remote Logging/Crash Logging/SentryEventSerializer.swift
+++ b/Sources/Remote Logging/Crash Logging/SentryEventSerializer.swift
@@ -27,9 +27,9 @@ struct SentryEventSerializer {
             try encode(header),
         ]
 
-        try events.forEach {
-            let data = try encode($0.value.serialize())
-            let header = AttachmentHeader(type: "event", length: data.count, content_type: "application/json", filename: $0.key)
+        try events.forEach { key, value in
+            let data = try encode(value.serialize())
+            let header = AttachmentHeader(type: "event", length: data.count, content_type: "application/json", filename: key)
             entries.append(try encode(header))
             entries.append(data)
         }


### PR DESCRIPTION
This is a bit of a personal take, so feel free to reject if you disagree.

It took me "a while" to understand that `events` was a Dictionary when reading `events.forEach { ... $0.key ... }`. I think explicitly calling the parameter `key, value` makes for easier to read code.

Incidentally, `key, value` is the approach used elsewhere in the same file, so this also makes the code consistent.