### PR TITLE
Add support for Sentry performance monitoring

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -36,6 +36,6 @@ Pod::Spec.new do |s|
   s.module_name = 'AutomatticTracks'
 
   s.ios.dependency 'UIDeviceIdentifier', '~> 2.0'
-  s.dependency 'Sentry', '~> 7.24.1'
+  s.dependency 'Sentry', '~> 7.25'
   s.dependency 'Sodium', '>= 0.9.1'
 end

--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '0.12.1-beta.2'
+  s.version       = '0.13.0-beta.1'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "946cbb6daccedf40d652a12138f78e96f660e1ad",
-          "version": "6.2.1"
+          "revision": "7acc8479b2c773dddacc7c5985e7ce9e4344f5f0",
+          "version": "7.25.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -42,11 +42,16 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "7.24.1"),
-        .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.0.0"),
-        .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.0.0"),
-        .package(name: "OCMock", url: "https://github.com/erikdoe/ocmock", .branch("master")),
+        // Runtime dependencies
+        //
+        // When changing these, make sure to update the matching declaration in
+        // the `podspec` file.
+        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "7.25.0"),
         .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium", from: "0.9.1"),
+        .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.0.0"),
+        // Tests dependencies
+        .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.0.0"),
+        .package(name: "OCMock", url: "https://github.com/erikdoe/ocmock", .branch("master")),
         .package(name: "BuildkiteTestCollector", url: "https://github.com/buildkite/test-collector-swift", from: "0.3.0"),
     ],
     targets: [

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.12.1-beta.2";
+NSString *const TracksLibraryVersion = @"0.13.0-beta.1";

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -56,7 +56,11 @@ public class CrashLogging {
 
             // Performance monitoring options
             options.enableAutoPerformanceTracking = self.dataProvider.enableAutoPerformanceTracking
-            options.tracesSampleRate = NSNumber(value: self.dataProvider.tracesSampleRate)
+            options.tracesSampler = { _ in
+                // To keep our implementation as Sentry agnostic as possible, we don't pass the
+                // input `SamplingContext` down the chain.
+                NSNumber(value: self.dataProvider.tracesSampler())
+            }
             options.enableNetworkTracking = self.dataProvider.enableNetworkTracking
             options.enableFileIOTracking = self.dataProvider.enableFileIOTracking
             options.enableCoreDataTracking = self.dataProvider.enableCoreDataTracking

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -53,6 +53,17 @@ public class CrashLogging {
 
             /// Attach stack traces to non-fatal errors
             options.attachStacktrace = true
+
+            // Performance monitoring options
+            options.enableAutoPerformanceTracking = self.dataProvider.enableAutoPerformanceTracking
+            options.tracesSampleRate = NSNumber(value: self.dataProvider.tracesSampleRate)
+            options.enableNetworkTracking = self.dataProvider.enableNetworkTracking
+            options.enableFileIOTracking = self.dataProvider.enableFileIOTracking
+            options.enableCoreDataTracking = self.dataProvider.enableCoreDataTracking
+            #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+                options.enableUserInteractionTracing = self.dataProvider.enableUserInteractionTracing
+                options.enableUIViewControllerTracking = self.dataProvider.enableUIViewControllerTracking
+            #endif
         }
 
         Internals.crashLogging = self

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -41,6 +41,11 @@ public extension CrashLoggingDataProvider {
         }
     }
 
+    var tracesSampler: PerformanceTracking.SampleRateGetter {
+        guard case .enabled(let config) = performanceTracking else { return { 0.0 } }
+        return config.sampleRateGetter
+    }
+
     var tracesSampleRate: Double {
         guard case .enabled(let config) = performanceTracking else { return 0.0 }
         return config.sampleRate

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -30,6 +30,10 @@ public extension CrashLoggingDataProvider {
         return false
     }
 
+    /// Performance tracking is disabled by default to avoid accidentally logging what could be a significant number of extra events
+    /// and blow up our budget monitoring.
+    var performanceTracking: PerformanceTracking { .disabled }
+
     var enableAutoPerformanceTracking: Bool {
         switch performanceTracking {
         case .enabled: return true

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -12,6 +12,7 @@ public protocol CrashLoggingDataProvider {
     var currentUser: TracksUser? { get }
     var additionalUserData: [String: Any] { get }
     var shouldEnableAutomaticSessionTracking: Bool { get }
+    var performanceTracking: PerformanceTracking { get }
 }
 
 /// Default implementations of common protocol properties
@@ -27,5 +28,42 @@ public extension CrashLoggingDataProvider {
 
     var shouldEnableAutomaticSessionTracking: Bool {
         return false
+    }
+
+    var enableAutoPerformanceTracking: Bool {
+        switch performanceTracking {
+        case .enabled: return true
+        case .disabled: return false
+        }
+    }
+
+    var tracesSampleRate: Double {
+        guard case .enabled(let config) = performanceTracking else { return 0.0 }
+        return config.sampleRate
+    }
+
+    var enableUIViewControllerTracking: Bool {
+        guard case .enabled(let config) = performanceTracking else { return false }
+        return config.trackViewControllers
+    }
+
+    var enableNetworkTracking: Bool {
+        guard case .enabled(let config) = performanceTracking else { return false }
+        return config.trackNetwork
+    }
+
+    var enableFileIOTracking: Bool {
+        guard case .enabled(let config) = performanceTracking else { return false }
+        return config.trackFileIO
+    }
+
+    var enableCoreDataTracking: Bool {
+        guard case .enabled(let config) = performanceTracking else { return false }
+        return config.trackCoreData
+    }
+
+    var enableUserInteractionTracing: Bool {
+        guard case .enabled(let config) = performanceTracking else { return false }
+        return config.trackUserInteraction
     }
 }

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -41,9 +41,9 @@ public extension CrashLoggingDataProvider {
         }
     }
 
-    var tracesSampler: PerformanceTracking.SampleRateGetter {
+    var tracesSampler: PerformanceTracking.Sampler {
         guard case .enabled(let config) = performanceTracking else { return { 0.0 } }
-        return config.sampleRateGetter
+        return config.sampler
     }
 
     var tracesSampleRate: Double {

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -31,7 +31,7 @@ public extension CrashLoggingDataProvider {
     }
 
     /// Performance tracking is disabled by default to avoid accidentally logging what could be a significant number of extra events
-    /// and blow up our budget monitoring.
+    /// and blow up our events budget.
     var performanceTracking: PerformanceTracking { .disabled }
 
     var enableAutoPerformanceTracking: Bool {

--- a/Sources/Remote Logging/Crash Logging/PerformanceTracking.swift
+++ b/Sources/Remote Logging/Crash Logging/PerformanceTracking.swift
@@ -1,7 +1,7 @@
 /// Defines whether to enable performance tracking, and if so, how to configure it.
 public enum PerformanceTracking {
 
-    public typealias SampleRateGetter = () -> Double
+    public typealias Sampler = () -> Double
 
     case disabled
     case enabled(Configuration)
@@ -13,7 +13,7 @@ public enum PerformanceTracking {
         /// This parameter allows clients to change the sample rate at runtime.
         ///
         /// - Important: The returned value must be between 0.0 (no events) and 1.0 (all events).
-        public let sampleRateGetter: SampleRateGetter
+        public let sampler: Sampler
         /// Defaults to `true`.
         public let trackCoreData: Bool
         /// Defaults to `true`.
@@ -32,17 +32,17 @@ public enum PerformanceTracking {
 
         // Compute the sample rate at runtime, to account for it accessing mutable state.
         // Clamp it between 0.0 and 1.0—the values Sentry uses.
-        var sampleRate: Double { min(max(sampleRateGetter(), 0.0), 1.0) }
+        var sampleRate: Double { min(max(sampler(), 0.0), 1.0) }
 
         public init(
-            sampleRateGetter: @escaping SampleRateGetter = { 0.1 },
+            sampler: @escaping Sampler = { 0.1 },
             trackCoreData: Bool = true,
             trackFileIO: Bool = true,
             trackNetwork: Bool = true,
             trackUserInteraction: Bool = true,
             trackViewControllers: Bool = true
         ) {
-            self.sampleRateGetter = sampleRateGetter
+            self.sampler = sampler
             self.trackCoreData = trackCoreData
             self.trackFileIO = trackFileIO
             self.trackNetwork = trackNetwork

--- a/Sources/Remote Logging/Crash Logging/PerformanceTracking.swift
+++ b/Sources/Remote Logging/Crash Logging/PerformanceTracking.swift
@@ -17,9 +17,13 @@ public enum PerformanceTracking {
         /// Defaults to `true`.
         public let trackNetwork: Bool
         /// Defaults to `true`.
+        ///
+        /// – Note: This is only read in iOS, tvOS, and Mac Catalyst clients, i.e. those with UIKit.
         public let trackUserInteraction: Bool
         /// Defaults to `true`.
+        ///
         /// - Note: As per the Sentry documentation, this only tracks first-party `UIViewController` subclasses. No SwiftUI views or third-party screens.
+        /// – Note: This is only read in iOS, tvOS, and Mac Catalyst clients, i.e. those with UIKit.
         public let trackViewControllers: Bool
 
         public init(

--- a/Sources/Remote Logging/Crash Logging/PerformanceTracking.swift
+++ b/Sources/Remote Logging/Crash Logging/PerformanceTracking.swift
@@ -1,0 +1,42 @@
+/// Defines whether to enable performance tracking, and if so, how to configure it.
+public enum PerformanceTracking {
+
+    case disabled
+    case enabled(Configuration)
+
+    /// Describe the configuration of the performance tracking functionality.
+    ///
+    /// – SeeAlso: The [Sentry docs](https://docs.sentry.io/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-tracking).
+    public struct Configuration {
+        /// - Important: Must be between 0.0 (no events) and 1.0 (all events).
+        public let sampleRate: Double
+        /// Defaults to `true`.
+        public let trackCoreData: Bool
+        /// Defaults to `true`.
+        public let trackFileIO: Bool
+        /// Defaults to `true`.
+        public let trackNetwork: Bool
+        /// Defaults to `true`.
+        public let trackUserInteraction: Bool
+        /// Defaults to `true`.
+        /// - Note: As per the Sentry documentation, this only tracks first-party `UIViewController` subclasses. No SwiftUI views or third-party screens.
+        public let trackViewControllers: Bool
+
+        public init(
+            sampleRate: Double,
+            trackCoreData: Bool = true,
+            trackFileIO: Bool = true,
+            trackNetwork: Bool = true,
+            trackUserInteraction: Bool = true,
+            trackViewControllers: Bool = true
+        ) {
+            // Force sample rate to be between 0.0 and 1.0.
+            self.sampleRate = min(max(0.0, sampleRate), 1.0)
+            self.trackCoreData = trackCoreData
+            self.trackFileIO = trackFileIO
+            self.trackNetwork = trackNetwork
+            self.trackUserInteraction = trackUserInteraction
+            self.trackViewControllers = trackViewControllers
+        }
+    }
+}

--- a/Sources/Remote Logging/Crash Logging/SentrySDK+CurrentHub.swift
+++ b/Sources/Remote Logging/Crash Logging/SentrySDK+CurrentHub.swift
@@ -1,11 +1,5 @@
 import Sentry
 
-@objc
-protocol SentrySDKInternalMethods {
-    @objc
-    var currentHub: SentryHub { get }
-}
-
 /// This is an extension on `SentrySDK` to hides the access to the `currentHub()` methods we use in
 /// the codebase.
 ///
@@ -17,17 +11,18 @@ protocol SentrySDKInternalMethods {
 extension SentrySDK {
 
     /// Returns the `Client` for the current `SentryHub`.
-    /// Since this method uses some Sentry internal methods to work, it may cease working entirely and start returning
-    /// `nil` when Sentry is updated.
     ///
+    /// - Note: Since this method uses some Sentry internal methods to work, it may cease working entirely and start returning
+    /// `nil` when Sentry is updated.
+    /// - SeeAlso: `_currentHub()`
     static func currentClient() -> Sentry.Client? {
         _currentHub()?.getClient()
     }
 
     /// Returns the current `SentryHub`.
-    /// Since this method uses some Sentry internal methods to work, it may cease working entirely and start returning
-    /// `nil` when Sentry is updated.
     ///
+    /// - Note: Since this method uses some Sentry internal methods to work, it may cease working entirely and start returning
+    /// `nil` when Sentry is updated.
     private static func _currentHub() -> SentryHub? {
         let currentHubSelector = #selector(getter: SentrySDKInternalMethods.currentHub)
 
@@ -37,4 +32,10 @@ extension SentrySDK {
 
         return SentrySDK.perform(currentHubSelector).takeUnretainedValue() as? SentryHub
     }
+}
+
+@objc
+protocol SentrySDKInternalMethods {
+    @objc
+    var currentHub: SentryHub { get }
 }

--- a/Sources/Remote Logging/EventLogging+Sentry.swift
+++ b/Sources/Remote Logging/EventLogging+Sentry.swift
@@ -22,13 +22,18 @@ extension EventLogging {
             return
         }
 
+        guard let timestamp = event.timestamp else {
+            TracksLogDebug("📜 Unable to locate event timestamp")
+            return
+        }
+
         /// Allow the hosting app to determine the most appropriate log file to send for the error type. For example, in an application using
         /// session-based file logging, the newest log file would be the current session, which is appropriate for debugging logs. However,
         /// the previous session's log file is the correct one for a crash, because when the crash is sent there will already be a new log
         /// file for the current session. Other apps may use time-based logs, in which case the same log would be the correct one.
         ///
         /// We also pass the timestamp for the event, as that can be useful for determining the correct log file.
-        guard let logFilePath = dataSource.logFilePath(forErrorLevel: event.errorType, at: event.timestamp ?? Date()) else {
+        guard let logFilePath = dataSource.logFilePath(forErrorLevel: event.errorType, at: timestamp) else {
             TracksLogDebug("📜 Unable to locate a log file to attach")
             return
         }

--- a/Tests/Tests/CrashLoggingTests.swift
+++ b/Tests/Tests/CrashLoggingTests.swift
@@ -158,10 +158,10 @@ class CrashLoggingTests: XCTestCase {
 
     func testPerformanceMonitoringConfigurationMappingWhenEnabled() {
         let dataProvider = MockCrashLoggingDataProvider()
-        dataProvider.performanceTracking = .enabled(.init(sampleRate: 0.12))
+        dataProvider.performanceTracking = .enabled(.init())
 
         XCTAssertTrue(dataProvider.enableAutoPerformanceTracking)
-        XCTAssertEqual(dataProvider.tracesSampleRate, 0.12)
+        XCTAssertEqual(dataProvider.tracesSampleRate, 0.1)
         XCTAssertTrue(dataProvider.enableCoreDataTracking)
         XCTAssertTrue(dataProvider.enableFileIOTracking)
         XCTAssertTrue(dataProvider.enableNetworkTracking)
@@ -175,7 +175,7 @@ class CrashLoggingTests: XCTestCase {
         let dataProvider = MockCrashLoggingDataProvider()
         dataProvider.performanceTracking = .enabled(
             .init(
-                sampleRate: 0.23,
+                sampleRateGetter: { 0.23 },
                 trackCoreData: false,
                 trackFileIO: true,
                 trackNetwork: false,

--- a/Tests/Tests/CrashLoggingTests.swift
+++ b/Tests/Tests/CrashLoggingTests.swift
@@ -175,7 +175,7 @@ class CrashLoggingTests: XCTestCase {
         let dataProvider = MockCrashLoggingDataProvider()
         dataProvider.performanceTracking = .enabled(
             .init(
-                sampleRateGetter: { 0.23 },
+                sampler: { 0.23 },
                 trackCoreData: false,
                 trackFileIO: true,
                 trackNetwork: false,

--- a/Tests/Tests/CrashLoggingTests.swift
+++ b/Tests/Tests/CrashLoggingTests.swift
@@ -128,6 +128,19 @@ class CrashLoggingTests: XCTestCase {
 //        wait(for: [expectation], timeout: 1)
 //    }
 
+    func testPerformanceMonitoringIsDisabledByDefault() {
+        let dataProvider = CrashLoggingDataProviderWithDefaultValuesOnly(
+            sentryDSN: "ignored-in-this-test",
+            userHasOptedOut: false,
+            buildType: "ignored-in-this-test",
+            currentUser: .none
+        )
+
+        guard case .disabled = dataProvider.performanceTracking else {
+            return XCTFail("Expected `CrashLoggingDataProvider` `performanceTracking` to default to `.disabled`. Got \(dataProvider) instead.")
+        }
+    }
+
     func testPerformanceMonitoringConfigurationMappingWhenDisabled() {
         let dataProvider = MockCrashLoggingDataProvider()
         dataProvider.performanceTracking = .disabled
@@ -206,4 +219,12 @@ private class MockCrashLoggingDataProvider: CrashLoggingDataProvider {
         currentUser = nil
         performanceTracking = .disabled
     }
+}
+
+/// Use this to get a `CrashLoggingDataProvider` implementation that allows testing the default values set via protocol extenstion.
+private struct CrashLoggingDataProviderWithDefaultValuesOnly: CrashLoggingDataProvider {
+    let sentryDSN: String
+    let userHasOptedOut: Bool
+    let buildType: String
+    let currentUser: TracksUser?
 }

--- a/Tests/Tests/PerformanceTrackingTests.swift
+++ b/Tests/Tests/PerformanceTrackingTests.swift
@@ -1,0 +1,22 @@
+#if SWIFT_PACKAGE
+@testable import AutomatticTracksModel
+@testable import AutomatticRemoteLogging
+#else
+@testable import AutomatticTracks
+#endif
+import XCTest
+
+class PerformanceTrackingTests: XCTestCase {
+
+    func testConfigurationSampleRateLowerBoundZero() {
+        XCTAssertEqual(PerformanceTracking.Configuration(sampleRate: 0.0).sampleRate, 0.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampleRate: -0.1).sampleRate, 0.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampleRate: -1.0).sampleRate, 0.0)
+    }
+
+     func testConfigurationSampleRateUpperBoundOne() {
+        XCTAssertEqual(PerformanceTracking.Configuration(sampleRate: 1.0).sampleRate, 1.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampleRate: 1.1).sampleRate, 1.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampleRate: 2.0).sampleRate, 1.0)
+     }
+}

--- a/Tests/Tests/PerformanceTrackingTests.swift
+++ b/Tests/Tests/PerformanceTrackingTests.swift
@@ -9,14 +9,14 @@ import XCTest
 class PerformanceTrackingTests: XCTestCase {
 
     func testConfigurationSampleRateLowerBoundZero() {
-        XCTAssertEqual(PerformanceTracking.Configuration(sampleRate: 0.0).sampleRate, 0.0)
-        XCTAssertEqual(PerformanceTracking.Configuration(sampleRate: -0.1).sampleRate, 0.0)
-        XCTAssertEqual(PerformanceTracking.Configuration(sampleRate: -1.0).sampleRate, 0.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampleRateGetter: { 0.0 }).sampleRate, 0.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampleRateGetter: { -0.1 }).sampleRate, 0.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampleRateGetter: { -1.0 }).sampleRate, 0.0)
     }
 
      func testConfigurationSampleRateUpperBoundOne() {
-        XCTAssertEqual(PerformanceTracking.Configuration(sampleRate: 1.0).sampleRate, 1.0)
-        XCTAssertEqual(PerformanceTracking.Configuration(sampleRate: 1.1).sampleRate, 1.0)
-        XCTAssertEqual(PerformanceTracking.Configuration(sampleRate: 2.0).sampleRate, 1.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampleRateGetter: { 1.0 }).sampleRate, 1.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampleRateGetter: { 1.1 }).sampleRate, 1.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampleRateGetter: { 2.0 }).sampleRate, 1.0)
      }
 }

--- a/Tests/Tests/PerformanceTrackingTests.swift
+++ b/Tests/Tests/PerformanceTrackingTests.swift
@@ -9,14 +9,14 @@ import XCTest
 class PerformanceTrackingTests: XCTestCase {
 
     func testConfigurationSampleRateLowerBoundZero() {
-        XCTAssertEqual(PerformanceTracking.Configuration(sampleRateGetter: { 0.0 }).sampleRate, 0.0)
-        XCTAssertEqual(PerformanceTracking.Configuration(sampleRateGetter: { -0.1 }).sampleRate, 0.0)
-        XCTAssertEqual(PerformanceTracking.Configuration(sampleRateGetter: { -1.0 }).sampleRate, 0.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampler: { 0.0 }).sampleRate, 0.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampler: { -0.1 }).sampleRate, 0.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampler: { -1.0 }).sampleRate, 0.0)
     }
 
      func testConfigurationSampleRateUpperBoundOne() {
-        XCTAssertEqual(PerformanceTracking.Configuration(sampleRateGetter: { 1.0 }).sampleRate, 1.0)
-        XCTAssertEqual(PerformanceTracking.Configuration(sampleRateGetter: { 1.1 }).sampleRate, 1.0)
-        XCTAssertEqual(PerformanceTracking.Configuration(sampleRateGetter: { 2.0 }).sampleRate, 1.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampler: { 1.0 }).sampleRate, 1.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampler: { 1.1 }).sampleRate, 1.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampler: { 2.0 }).sampleRate, 1.0)
      }
 }

--- a/TracksDemo/Shared/CrashLoggingDataSource.swift
+++ b/TracksDemo/Shared/CrashLoggingDataSource.swift
@@ -12,4 +12,8 @@ struct CrashLoggingDataSource: CrashLoggingDataProvider {
     }
 
     var shouldEnableAutomaticSessionTracking = true
+
+    // This is a demo app, we can afford to sample all events. However, Sentry recomends a lower
+    // sample rate in production.
+    var performanceTracking: PerformanceTracking = .enabled(.init(sampleRate: 1.0))
 }

--- a/TracksDemo/Shared/CrashLoggingDataSource.swift
+++ b/TracksDemo/Shared/CrashLoggingDataSource.swift
@@ -15,5 +15,5 @@ struct CrashLoggingDataSource: CrashLoggingDataProvider {
 
     // This is a demo app, we can afford to sample all events. However, Sentry recomends a lower
     // sample rate in production.
-    var performanceTracking: PerformanceTracking = .enabled(.init(sampleRateGetter: { 1.0 }))
+    var performanceTracking: PerformanceTracking = .enabled(.init(sampler: { 1.0 }))
 }

--- a/TracksDemo/Shared/CrashLoggingDataSource.swift
+++ b/TracksDemo/Shared/CrashLoggingDataSource.swift
@@ -15,5 +15,5 @@ struct CrashLoggingDataSource: CrashLoggingDataProvider {
 
     // This is a demo app, we can afford to sample all events. However, Sentry recomends a lower
     // sample rate in production.
-    var performanceTracking: PerformanceTracking = .enabled(.init(sampleRate: 1.0))
+    var performanceTracking: PerformanceTracking = .enabled(.init(sampleRateGetter: { 1.0 }))
 }

--- a/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "4a60ff4287d4c6ac64085ad48606ef5ecaec9817",
-          "version": "7.24.1"
+          "revision": "7acc8479b2c773dddacc7c5985e7ce9e4344f5f0",
+          "version": "7.25.0"
         }
       },
       {


### PR DESCRIPTION
Version 7.0 introduced performance monitoring. To prove the upgrade was successful, visit the [performance page for the demo app](https://sentry.io/organizations/a8c/performance/summary/?project=5591863&query=&statsPeriod=24h&transaction=ViewController&unselectedSeries=p100%28%29):

![image](https://user-images.githubusercontent.com/1218433/187613841-eeb51fe7-157d-4eb6-9e57-3b6686fd7658.png)

I also checked that reporting still works. The screenshot below shows events I sent via the Tracks Demo iOS app:

<img width="1598" alt="image" src="https://user-images.githubusercontent.com/1218433/187611964-07251f1d-50db-4d54-8316-8bf3252ceea8.png">

_Notice the UTC timestamp in Sentry and the AEST time in my macOS clock._ 

You can also see the individual events here:

- https://sentry.io/organizations/a8c/issues/3532675432/?project=5591863&statsPeriod=24h
- https://sentry.io/organizations/a8c/issues/3530809730/?project=5591863&statsPeriod=24h