### PR TITLE
Improves the error logging in `[TracksContextManager persistentStoreCoordinator]`.

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '0.12.0'
+  s.version       = '0.12.1-beta.1'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/Sources/Model/ObjC/Common/Core Data/TracksContextManager.m
+++ b/Sources/Model/ObjC/Common/Core Data/TracksContextManager.m
@@ -46,11 +46,13 @@ NSString *const TracksPersistentStoreException      = @"TracksPersistentStoreExc
     _persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[self managedObjectModel]];
     NSURL *storeURL = [self storeURL];
     NSError *error = nil;
-    if (![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
+    if (true || ![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
         
         // Delete the store and try again
         [[NSFileManager defaultManager] removeItemAtPath:storeURL.path error:nil];
-        if (![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
+        if (true || ![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
+            
+            error = [NSError errorWithDomain:@"asd" code:1 userInfo:nil];
             
             // This is not really an officially public way to check for prewarming, but it's the only way we have to
             // check it, and since this information is extremely important for being able to debug issues here

--- a/Sources/Model/ObjC/Common/Core Data/TracksContextManager.m
+++ b/Sources/Model/ObjC/Common/Core Data/TracksContextManager.m
@@ -46,13 +46,11 @@ NSString *const TracksPersistentStoreException      = @"TracksPersistentStoreExc
     _persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[self managedObjectModel]];
     NSURL *storeURL = [self storeURL];
     NSError *error = nil;
-    if (true || ![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
+    if (![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
         
         // Delete the store and try again
         [[NSFileManager defaultManager] removeItemAtPath:storeURL.path error:nil];
-        if (true || ![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
-            
-            error = [NSError errorWithDomain:@"asd" code:1 userInfo:nil];
+        if (![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
             
             // This is not really an officially public way to check for prewarming, but it's the only way we have to
             // check it, and since this information is extremely important for being able to debug issues here

--- a/Sources/Model/ObjC/Common/Core Data/TracksContextManager.m
+++ b/Sources/Model/ObjC/Common/Core Data/TracksContextManager.m
@@ -51,9 +51,16 @@ NSString *const TracksPersistentStoreException      = @"TracksPersistentStoreExc
         // Delete the store and try again
         [[NSFileManager defaultManager] removeItemAtPath:storeURL.path error:nil];
         if (![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
+            
+            // This is not really an officially public way to check for prewarming, but it's the only way we have to
+            // check it, and since this information is extremely important for being able to debug issues here
+            // it's worth including it.  Worst case scenario this could cease working, but should not cause any issues
+            // whatsoever.
+            NSString *prewarming = [NSProcessInfo processInfo].environment[@"ActivePrewarm"] ?: @"0";
+            
             // Replace this with code to handle the error appropriately.
             // abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-            TracksLogError(@"Unresolved error %@, %@", error, [error userInfo]);
+            TracksLogError(@"Unresolved error %@, %@. Context info {prewarming=%@, storeURL=%@}.", error, [error userInfo], prewarming, storeURL);
             
             @throw [NSException exceptionWithName:TracksPersistentStoreException
                                            reason:[NSString stringWithFormat:@"Error initializing Tracks: %@", error]

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.12.0";
+NSString *const TracksLibraryVersion = @"0.12.1-beta.1";


### PR DESCRIPTION
Improves the error logging in `[TracksContextManager persistentStoreCoordinator]` to try and detect possible issues with the URLs and prewarming.

This is because we're seeing failures in DO where the file cannot be created.

## Testing:

1. Make these two conditions always succeed by prepending them with `true ||`:

https://github.com/Automattic/Automattic-Tracks-iOS/blob/716bf8f5e06937cdce8801e8be22bf70abf01ce3/Sources/Model/ObjC/Common/Core%20Data/TracksContextManager.m#L49

and 

https://github.com/Automattic/Automattic-Tracks-iOS/blob/716bf8f5e06937cdce8801e8be22bf70abf01ce3/Sources/Model/ObjC/Common/Core%20Data/TracksContextManager.m#L53

2. Add the following line [here](https://github.com/Automattic/Automattic-Tracks-iOS/blob/716bf8f5e06937cdce8801e8be22bf70abf01ce3/Sources/Model/ObjC/Common/Core%20Data/TracksContextManager.m#L54):

```objc
error = [NSError errorWithDomain:"testing" code:1 userInfo:nil];
```

3. Make sure you've set the Sentry's DSN in `Settings.swift` (there's a tracks demo android project) so you can run the demo App.

4. Run the demo app

Make sure you see something like this in your log when it crashes:

```text
Tracks <E>: Unresolved error Error Domain=asd Code=1 "(null)", {
}. Context info {prewarming=0, storeURL=file:///Users/kybos/Library/Developer/CoreSimulator/Devices/056C5AA2-93D7-459C-88FC-8922966C81F0/data/Containers/Data/Application/35DB0537-8EE3-47F1-9510-6F55529B3F84/Library/Application%20Support/com.automattic.TracksDemo/Tracks.sqlite}.
```

