### PR TITLE
Updates to sentry 7.24.1

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '0.12.1-beta.1'
+  s.version       = '0.12.1-beta.2'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC
@@ -36,6 +36,6 @@ Pod::Spec.new do |s|
   s.module_name = 'AutomatticTracks'
 
   s.ios.dependency 'UIDeviceIdentifier', '~> 2.0'
-  s.dependency 'Sentry', '~> 6'
+  s.dependency 'Sentry', '~> 7.24.1'
   s.dependency 'Sodium', '>= 0.9.1'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "6.0.0"),
+        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "7.24.1"),
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.0.0"),
         .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.0.0"),
         .package(name: "OCMock", url: "https://github.com/erikdoe/ocmock", .branch("master")),

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.12.1-beta.1";
+NSString *const TracksLibraryVersion = @"0.12.1-beta.2";

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -168,7 +168,7 @@ public extension CrashLogging {
             )
 
             event.threads = currentThreads()
-            
+
             serializer.add(event: event)
         }
 

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -167,7 +167,9 @@ public extension CrashLogging {
                 extra: userInfo ?? (error as NSError).userInfo
             )
 
-            serializer.add(event: addStackTrace(to: event))
+            event.threads = currentThreads()
+            
+            serializer.add(event: event)
         }
 
         guard let requestBody = try? serializer.serialize() else {
@@ -231,13 +233,17 @@ public extension CrashLogging {
         }
     }
 
-    /// A wrapper around the `SentryClient` shim – keeps each layer clean by avoiding optionality
-    private func addStackTrace(to event: Event) -> Event {
+    /// Returns an array of threads for the current stack trace.  This hack is needed because we don't have
+    /// any public mechanism to access the stack trace threads to add them to our custom events.
+    ///
+    /// Ref: https://github.com/getsentry/sentry-cocoa/issues/1451#issuecomment-1240782406
+    ///
+    private func currentThreads() -> [Sentry.Thread] {
         guard let client = SentrySDK.currentClient() else {
-            return event
+            return []
         }
 
-        return client.addStackTrace(to: event, for: client)
+        return client.currentThreads()
     }
 }
 

--- a/Sources/Remote Logging/Crash Logging/SentryClient+Shim.swift
+++ b/Sources/Remote Logging/Crash Logging/SentryClient+Shim.swift
@@ -9,7 +9,7 @@ private protocol SentryClientInternalMethods {
                       alwaysAttachStacktrace: Bool,
                       isCrashEvent: Bool
     ) -> Sentry.Event?
-    
+
     @objc(threadInspector)
     func threadInspector() -> Any
 }
@@ -18,11 +18,11 @@ private protocol SentryClientInternalMethods {
 private protocol SentryThreadInspectorInternalMethods {
     @objc(getCurrentThreads)
     func getCurrentThreads() -> [Sentry.Thread]
-    
+
 }
 
 extension Sentry.Client {
-    
+
     /// Returns an array of threads for the current stack trace.  This hack is needed because we don't have
     /// any public mechanism to access the stack trace threads to add them to our custom events.
     ///
@@ -30,18 +30,18 @@ extension Sentry.Client {
     ///
     func currentThreads() -> [Sentry.Thread] {
         let threadInspectorSelector = #selector(SentryClientInternalMethods.threadInspector)
-        
+
         guard responds(to: threadInspectorSelector) else {
             return []
         }
-        
+
         let threadInspector = perform(threadInspectorSelector).takeUnretainedValue()
         let getCurrentThreadsSelector = #selector(SentryThreadInspectorInternalMethods.getCurrentThreads)
-        
+
         guard threadInspector.responds(to: getCurrentThreadsSelector) else {
             return []
         }
-        
+
         let threads = threadInspector.perform(getCurrentThreadsSelector).takeUnretainedValue() as? [Sentry.Thread]
         return threads ?? []
     }

--- a/Sources/Remote Logging/Crash Logging/SentryClient+Shim.swift
+++ b/Sources/Remote Logging/Crash Logging/SentryClient+Shim.swift
@@ -2,47 +2,47 @@ import Sentry
 
 
 @objc
-private protocol SentryClient_InternalMethods {
+private protocol SentryClientInternalMethods {
     @objc(prepareEvent:withScope:alwaysAttachStacktrace:isCrashEvent:)
     func prepareEvent(_ e: Sentry.Event,
                       withScope: Sentry.Scope,
                       alwaysAttachStacktrace: Bool,
                       isCrashEvent: Bool
     ) -> Sentry.Event?
+    
+    @objc(threadInspector)
+    func threadInspector() -> Any
+}
+
+@objc
+private protocol SentryThreadInspectorInternalMethods {
+    @objc(getCurrentThreads)
+    func getCurrentThreads() -> [Sentry.Thread]
+    
 }
 
 extension Sentry.Client {
-    /*
-     * A wrapper around a private method in `SentryClient`. If it's unavailable (say the library
-     changes),
-     * the worst that should happen is that the stack trace is no longer available on events sent
-     manually using this method.
-     *
-     * We can remove this once the Sentry SDK allows for capturing events and being notified once
-     they're delivered.
-     * ref: https://github.com/getsentry/sentry-cocoa/issues/660
-     */
-    @objc(addStackTraceToEvent:forClient:)
-    func addStackTrace(to event: Sentry.Event, for client: Sentry.Client) -> Sentry.Event {
-
-        let sel = #selector(SentryClient_InternalMethods.prepareEvent(_:withScope:alwaysAttachStacktrace:isCrashEvent:))
-
-        if !client.responds(to: sel) {
-            return event
+    
+    /// Returns an array of threads for the current stack trace.  This hack is needed because we don't have
+    /// any public mechanism to access the stack trace threads to add them to our custom events.
+    ///
+    /// Ref: https://github.com/getsentry/sentry-cocoa/issues/1451#issuecomment-1240782406
+    ///
+    func currentThreads() -> [Sentry.Thread] {
+        let threadInspectorSelector = #selector(SentryClientInternalMethods.threadInspector)
+        
+        guard responds(to: threadInspectorSelector) else {
+            return []
         }
-
-        guard let scope = SentrySDK.currentScope() else {
-            return event
+        
+        let threadInspector = perform(threadInspectorSelector).takeUnretainedValue()
+        let getCurrentThreadsSelector = #selector(SentryThreadInspectorInternalMethods.getCurrentThreads)
+        
+        guard threadInspector.responds(to: getCurrentThreadsSelector) else {
+            return []
         }
-
-        guard let eventWithStackTrace = (self as AnyObject).prepareEvent(event, withScope: scope, alwaysAttachStacktrace: true, isCrashEvent: false)
-        else {
-            return event
-        }
-
-        if let stackTrace = eventWithStackTrace.threads?.first?.stacktrace {
-            eventWithStackTrace.stacktrace = stackTrace
-        }
-        return event
+        
+        let threads = threadInspector.perform(getCurrentThreadsSelector).takeUnretainedValue() as? [Sentry.Thread]
+        return threads ?? []
     }
 }

--- a/Sources/Remote Logging/Crash Logging/SentrySDK+CurrentHub.swift
+++ b/Sources/Remote Logging/Crash Logging/SentrySDK+CurrentHub.swift
@@ -30,11 +30,11 @@ extension SentrySDK {
     /// will no longer be available.
     private static func _currentHub() -> SentryHub? {
         let currentHubSelector = #selector(getter: SentrySDKInternalMethods.currentHub)
-        
+
         guard SentrySDK.responds(to: currentHubSelector) else {
             return nil
         }
-        
+
         return SentrySDK.perform(currentHubSelector).takeUnretainedValue() as? SentryHub
     }
 }

--- a/Sources/Remote Logging/Crash Logging/SentrySDK+CurrentHub.swift
+++ b/Sources/Remote Logging/Crash Logging/SentrySDK+CurrentHub.swift
@@ -17,17 +17,17 @@ protocol SentrySDKInternalMethods {
 extension SentrySDK {
 
     /// Returns the `Client` for the current `SentryHub`.
+    /// Since this method uses some Sentry internal methods to work, it may cease working entirely and start returning
+    /// `nil` when Sentry is updated.
     ///
-    /// - Note: Once we'll migrate to version 7.x, this will return `.none` because `currentHub`
-    /// will no longer be available.
     static func currentClient() -> Sentry.Client? {
         _currentHub()?.getClient()
     }
 
     /// Returns the current `SentryHub`.
+    /// Since this method uses some Sentry internal methods to work, it may cease working entirely and start returning
+    /// `nil` when Sentry is updated.
     ///
-    /// - Note: Once we'll migrate to version 7.x, this will return `.none` because `currentHub`
-    /// will no longer be available.
     private static func _currentHub() -> SentryHub? {
         let currentHubSelector = #selector(getter: SentrySDKInternalMethods.currentHub)
 

--- a/Sources/Remote Logging/EventLogging+Sentry.swift
+++ b/Sources/Remote Logging/EventLogging+Sentry.swift
@@ -28,7 +28,7 @@ extension EventLogging {
         /// file for the current session. Other apps may use time-based logs, in which case the same log would be the correct one.
         ///
         /// We also pass the timestamp for the event, as that can be useful for determining the correct log file.
-        guard let logFilePath = dataSource.logFilePath(forErrorLevel: event.errorType, at: event.timestamp) else {
+        guard let logFilePath = dataSource.logFilePath(forErrorLevel: event.errorType, at: event.timestamp ?? Date()) else {
             TracksLogDebug("📜 Unable to locate a log file to attach")
             return
         }

--- a/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "946cbb6daccedf40d652a12138f78e96f660e1ad",
-          "version": "6.2.1"
+          "revision": "4a60ff4287d4c6ac64085ad48606ef5ecaec9817",
+          "version": "7.24.1"
         }
       },
       {


### PR DESCRIPTION
Updates to Sentry 7.24.1

Resolves https://github.com/Automattic/Automattic-Tracks-iOS/issues/181 (through a hack, though)

## Details:

I posted [a request](https://github.com/getsentry/sentry-cocoa/issues/1451#issuecomment-1240782406) in one of our old issues in the Sentry repo so that we can hopefully avoid having these hacks in-place.

Unfortunately I don't think it's possible to avoid these hacks right now, until we do larger changes on our end.

This PR aims specifically to unblock us and allow us to update to the latest Sentry version.

## Testing:

You'll need to set-up the DSN in `Secrets.swift`.

1. Place breakpoints in the places where I changed the code to see that the selectors don't fail and return reasonable values.
2. Launch the Demo iOS app.
3. Select "Crashes" in the bottom tab bar.
4. Tap on "Send Error and Wait" and inspect the values in the breakpoints you placed to ensure we're getting the right data.