### PR TITLE
Quickfix: Disable Sentry `debug` mode and set logging level to `.error`

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '0.13.0-beta.1'
+  s.version       = '0.13.0-beta.2'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"0.13.0-beta.1";
+NSString *const TracksLibraryVersion = @"0.13.0-beta.2";

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -43,7 +43,9 @@ public class CrashLogging {
 
         SentrySDK.start { options in
             options.dsn = self.dataProvider.sentryDSN
-            options.debug = true
+
+            options.debug = false
+            options.diagnosticLevel = .error
 
             options.environment = self.dataProvider.buildType
             options.releaseName = self.dataProvider.releaseName

--- a/Sources/Remote Logging/Crash Logging/LogLevel.swift
+++ b/Sources/Remote Logging/Crash Logging/LogLevel.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Gio Lodi on 15/9/2022.
+//
+
+import Foundation


### PR DESCRIPTION
[Logging level became `.debug` by default in Sentry 7.x](https://docs.sentry.io/platforms/apple/guides/macos/migration/#sentryloglevel), which could result in too much noise in the Xcode console.

Sentry has six logging levels:

- none
- debug
- info
- warning
- error
- fatal

This is a **quickfix proposal** to address the immediate issue of overwhelming logs in Tracks version starting from `0.12.1-beta.2`.

A better long term approach would be to define a Tracks-scoped logging level type and add it to `CrashLoggingDataProvider` to allow clients to configure it.

I noticed we already have an `EventLoggingErrorType` (`.fatal`, `.debug`). That could be a starting point, but is not as refined as Sentry's. It also sets the expectation that it should be used only for errors.

Another option might be to introduce `swift-log` as a dependency (which in itself has drawbacks) and [use its `Logger.Level` type](https://github.com/apple/swift-log/blob/ce09fe6dac03e7640d3fa7cce25936ea446baf5f/Sources/Logging/Logging.swift#L745-L779).

That's all to say, I don't want to rush into picking an option which, if we wanted to move away from, would break all the clients. Because of that, I think we should merge this quick fix first.

If you agree with my approach, I'll add a version bump commit before merging.