### PR TITLE
Update ABTesting Variation representation.

### DIFF
--- a/Sources/Experiments/ABTesting.swift
+++ b/Sources/Experiments/ABTesting.swift
@@ -2,7 +2,8 @@ import Foundation
 
 public enum Variation: Equatable {
     case control
-    case treatment(String?)
+    case treatment
+    case customTreatment(name: String)
 }
 
 /// A protocol that defines a A/B Testing provider

--- a/Sources/Experiments/ExPlat.swift
+++ b/Sources/Experiments/ExPlat.swift
@@ -105,9 +105,9 @@ import Cocoa
         case "control":
             return .control
         case "treatment":
-            return .treatment(nil)
-        default:
-            return .treatment(variation)
+            return .treatment
+        case let name:
+            return .customTreatment(name: name)
         }
     }
 

--- a/Tests/Tests/ABTesting/ExPlatTests.swift
+++ b/Tests/Tests/ABTesting/ExPlatTests.swift
@@ -22,8 +22,8 @@ class ExPlatTests: XCTestCase {
 
         abTesting.refresh {
             XCTAssertEqual(abTesting.experiment("experiment"), .control)
-            XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment(nil))
-            XCTAssertEqual(abTesting.experiment("experiment_multiple_variation"), .treatment("another_treatment"))
+            XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment)
+            XCTAssertEqual(abTesting.experiment("experiment_multiple_variation"), .customTreatment(name: "another_treatment"))
             expectation.fulfill()
         }
 
@@ -44,12 +44,12 @@ class ExPlatTests: XCTestCase {
             serviceMock.ttl = 60
             serviceMock.experimentVariation = "treatment"
             abTesting.refreshIfNeeded {
-                XCTAssertEqual(abTesting.experiment("experiment"), .treatment(nil))
+                XCTAssertEqual(abTesting.experiment("experiment"), .treatment)
 
                 // Should not change "experiment" to control
                 serviceMock.experimentVariation = "control"
                 abTesting.refreshIfNeeded {
-                    XCTAssertEqual(abTesting.experiment("experiment"), .treatment(nil))
+                    XCTAssertEqual(abTesting.experiment("experiment"), .treatment)
                     expectation.fulfill()
                 }
             }
@@ -71,8 +71,8 @@ class ExPlatTests: XCTestCase {
             serviceMock.returnAssignments = false
             abTesting.refresh {
                 XCTAssertEqual(abTesting.experiment("experiment"), .control)
-                XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment(nil))
-                XCTAssertEqual(abTesting.experiment("experiment_multiple_variation"), .treatment("another_treatment"))
+                XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment)
+                XCTAssertEqual(abTesting.experiment("experiment_multiple_variation"), .customTreatment(name: "another_treatment"))
                 expectation.fulfill()
             }
 


### PR DESCRIPTION
Most AB tests run with just `control` and `treatment` variations. These were curiously represented in the Tracks code as `.control` and `.treatment(nil)`, respectively. That `nil` is quite confusing for such a common case.

This PR updates the representation of the common case to simply be `.treatment`. Custom cases are now represented with a separate enum value.

Treatment name from server | Old representation | New representation
---|---|---
`"control"` | `.control` | `.control`
`"treatment"` | `.treatment(nil)` | `.treatment`
`"purple_button"` | `.treatment("purple_button")` | `.customTreatment(name: "purple_button")`

Fixes #226
