### PR TITLE
Dispatch an UI update event in the macOS demo app from the main thread

### DIFF
--- a/TracksDemo/TracksDemo Mac/ViewController.swift
+++ b/TracksDemo/TracksDemo Mac/ViewController.swift
@@ -116,8 +116,10 @@ class ViewController: NSViewController {
 
     // MARK: - Helpers
     private func updateObjectCountLabel() {
-        let count = fetchedResultsController.fetchedObjects?.count ?? 0
-        queuedEventsLabel.stringValue = "Number of events queued: \(count)"
+        DispatchQueue.main.async { [weak self] in
+            let count = self?.fetchedResultsController.fetchedObjects?.count ?? 0
+            self?.queuedEventsLabel.stringValue = "Number of events queued: \(count)"
+        }
     }
 
     private func switchToAnonymousUser() {


### PR DESCRIPTION
Xcode showed a Main Thread Sanitizer warning about this:

<img width="1602" alt="image" src="https://user-images.githubusercontent.com/1218433/196073864-b97df06e-59ad-45f9-b71c-abb86ad0b049.png">

If you run the app on this branch, you'll see no warning.

_I noticed this while experimenting with Sentry's `flush` in #232._