### PR TITLE
Update `CrashLoggingView` after adopting Sentry `flush`, and remove dead `throws`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ _None._
 ### Breaking Changes
 
 - `logErrorImmediately` and `logErrorsImmediately` no longer have a `Result` parameter in their callback [#232]
+- `logErrorImmediately` and `logErrorsImmediately` no longer `throws` [#236]
 
 ### New Features
 

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -176,11 +176,11 @@ public extension CrashLogging {
     }
 
     /// Sends an `Event` to Sentry and triggers a callback on completion
-    func logErrorImmediately(_ error: Error, userInfo: [String: Any]? = nil, level: SentryLevel = .error, callback: @escaping () -> Void) throws {
-        try logErrorsImmediately([error], userInfo: userInfo, level: level, callback: callback)
+    func logErrorImmediately(_ error: Error, userInfo: [String: Any]? = nil, level: SentryLevel = .error, callback: @escaping () -> Void) {
+        logErrorsImmediately([error], userInfo: userInfo, level: level, callback: callback)
     }
 
-    func logErrorsImmediately(_ errors: [Error], userInfo: [String: Any]? = nil, level: SentryLevel = .error, callback: @escaping () -> Void) throws {
+    func logErrorsImmediately(_ errors: [Error], userInfo: [String: Any]? = nil, level: SentryLevel = .error, callback: @escaping () -> Void) {
         logErrorsImmediately(errors, userInfo: userInfo, level: level, andWait: false, callback: callback)
     }
 
@@ -192,7 +192,7 @@ public extension CrashLogging {
      - userInfo: A dictionary containing additional data about this error.
      - level: The level of severity to report in Sentry (`.error` by default)
      */
-    func logErrorAndWait(_ error: Error, userInfo: [String: Any]? = nil, level: SentryLevel = .error) throws {
+    func logErrorAndWait(_ error: Error, userInfo: [String: Any]? = nil, level: SentryLevel = .error) {
         logErrorsImmediately([error], userInfo: userInfo, level: level, andWait: true, callback: {})
         TracksLogDebug("💥 Events flush completed. When using Sentry, this either means all events were sent or that the flush timeout was reached.")
     }

--- a/Sources/UI/Crash Logging/CrashLoggingView.swift
+++ b/Sources/UI/Crash Logging/CrashLoggingView.swift
@@ -42,10 +42,8 @@ public struct CrashLoggingView: View {
                                     Group {} /// An empty view
                                 case .uploading:
                                     Text("⏳")
-                                case .success:
+                                case .done:
                                     Text("✅")
-                                case .error:
-                                    Text("⚠️")
                             }
                         }
                     }
@@ -63,8 +61,7 @@ public struct CrashLoggingView: View {
     enum SendErrorAndWaitStatus {
         case none
         case uploading
-        case success
-        case error
+        case done
     }
 }
 
@@ -101,11 +98,10 @@ extension CrashLoggingView {
                 error,
                 userInfo: ["custom-userInfo-key": "custom-userInfo-value"]
             ) {
-                sendErrorAndWaitStatus = .success
+                sendErrorAndWaitStatus = .done
             }
-        } catch let err {
-            sendingError = err
-            sendErrorAndWaitStatus = .error
+        } catch {
+            sendErrorAndWaitStatus = .done
         }
     }
 }

--- a/Sources/UI/Crash Logging/CrashLoggingView.swift
+++ b/Sources/UI/Crash Logging/CrashLoggingView.swift
@@ -93,14 +93,10 @@ extension CrashLoggingView {
 
         let error = SentryTestError(title: "Test Error")
 
-        do {
-            try crashLogging.logErrorImmediately(
-                error,
-                userInfo: ["custom-userInfo-key": "custom-userInfo-value"]
-            ) {
-                sendErrorAndWaitStatus = .done
-            }
-        } catch {
+        crashLogging.logErrorImmediately(
+            error,
+            userInfo: ["custom-userInfo-key": "custom-userInfo-value"]
+        ) {
             sendErrorAndWaitStatus = .done
         }
     }


### PR DESCRIPTION
We no longer have error handling because of Sentry's `flush`, so having `success` and `error` states would be misleading. Likewise, none of the leftover code `throw` errors and there is no point in requiring callers to add `do catch` to use this code.

This is leftover work from #232. That PR has already been approved, so I created a new one to avoid noise.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
