### PR TITLE
Print a log message if user blocked events sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Log a message if events won't be collected because the user opted out [#239]
 
 -->
 

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -96,6 +96,10 @@ public class CrashLogging {
         let shouldSendEvent = !dataProvider.userHasOptedOut
         #endif
 
+        if shouldSendEvent == false {
+            TracksLogDebug("📜 Events will not be sent because user has opted-out.")
+        }
+
         /// If we shouldn't send the event we have nothing else to do here
         guard let event = event, shouldSendEvent else {
             return nil


### PR DESCRIPTION
While [investigating the `flush` behavior in WooCommerce](https://github.com/Automattic/Automattic-Tracks-iOS/issues/225#issuecomment-1324924475), it took me more than I care to admit to realize I wasn't seeing events because my Simulator was simply not sending them.

This additional log should help realize that sooner in the future.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
