### PR TITLE
Remove Swift Package Manager workaround for Xcode 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,4 +49,4 @@ _None._
 
 - Add this changelog file [#234]
 - Log a message if events won't be collected because the user opted out [#239]
-- Tracks now requires at least Xcode 13.
+- Tracks now requires at least Xcode 13. [#244]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,4 @@ _None._
 
 - Add this changelog file [#234]
 - Log a message if events won't be collected because the user opted out [#239]
+- Tracks now requires at least Xcode 13.

--- a/Package.swift
+++ b/Package.swift
@@ -27,19 +27,6 @@ let package = Package(
             name: "AutomatticEncryptedLogs",
             targets: ["AutomatticEncryptedLogs"]
         ),
-
-        // Xcode 12 has an issue where the first build after
-        // cleaning fails if there is a dependency that vends
-        // a binary .xcframework. We are working around this
-        // on CI by first building this "_WorkaroundSPM"
-        // target that _only_ builds that one dependency.
-        // We ignore any failures when building this target.
-        // Then we go on to build the actual product, which
-        // builds correctly.
-        .library(
-            name: "_WorkaroundSPM",
-            targets: ["_WorkaroundSPM"]
-        )
     ],
     dependencies: [
         // Runtime dependencies
@@ -183,11 +170,5 @@ let package = Package(
             ],
             path: "Tests/Tests/ObjC"
         ),
-
-        .target(
-            name: "_WorkaroundSPM",
-            dependencies: ["Sodium"],
-            path: "Sources/Workaround-SPM"
-        )
     ]
 )


### PR DESCRIPTION
We had an extra target in Package.swift to fix a build issue when using Xcode 12. We no longer need the workaround since we're not building with Xcode 12 anymore, so I'm removing it.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
