### PR TITLE
Upgrade to Sentry SDK 8.3, and expose profiling as an option.

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -36,6 +36,6 @@ Pod::Spec.new do |s|
   s.module_name = 'AutomatticTracks'
 
   s.ios.dependency 'UIDeviceIdentifier', '~> 2.0'
-  s.dependency 'Sentry', '~> 7.25'
+  s.dependency 'Sentry', '~> 8.0'
   s.dependency 'Sodium', '>= 0.9.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ _None._
 
 ### New Features
 
-_None._
+- The Sentry SDK has been updated to version 8.0.0, and now exposes [Performance Profiling](https://docs.sentry.io/product/profiling/) as an option. [#245]
 
 ### Bug Fixes
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "4f6838af2688f8f762afdaea5bef941121e7d473",
-          "version": "8.0.0"
+          "revision": "c85564d7c92adb28f7ee15e2d758b67d7bfd06bd",
+          "version": "8.3.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "dc00a3673e3d313e41326bd53802f757defd0eee",
-          "version": "7.28.0"
+          "revision": "4f6838af2688f8f762afdaea5bef941121e7d473",
+          "version": "8.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         //
         // When changing these, make sure to update the matching declaration in
         // the `podspec` file.
-        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "7.26.0"),
+        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "8.0.0"),
         .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium", from: "0.9.1"),
         .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.0.0"),
         // Tests dependencies

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -71,6 +71,7 @@ public class CrashLogging {
                 // input `SamplingContext` down the chain.
                 NSNumber(value: self.dataProvider.tracesSampler())
             }
+            options.profilesSampleRate = NSNumber(value: self.dataProvider.profilingRate)
             options.enableNetworkTracking = self.dataProvider.enableNetworkTracking
             options.enableFileIOTracing = self.dataProvider.enableFileIOTracking
             options.enableCoreDataTracing = self.dataProvider.enableCoreDataTracking

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -65,18 +65,18 @@ public class CrashLogging {
             options.attachStacktrace = true
 
             // Performance monitoring options
-            options.enableAutoPerformanceTracking = self.dataProvider.enableAutoPerformanceTracking
+            options.enableAutoPerformanceTracing = self.dataProvider.enableAutoPerformanceTracking
             options.tracesSampler = { _ in
                 // To keep our implementation as Sentry agnostic as possible, we don't pass the
                 // input `SamplingContext` down the chain.
                 NSNumber(value: self.dataProvider.tracesSampler())
             }
             options.enableNetworkTracking = self.dataProvider.enableNetworkTracking
-            options.enableFileIOTracking = self.dataProvider.enableFileIOTracking
-            options.enableCoreDataTracking = self.dataProvider.enableCoreDataTracking
+            options.enableFileIOTracing = self.dataProvider.enableFileIOTracking
+            options.enableCoreDataTracing = self.dataProvider.enableCoreDataTracking
             #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
                 options.enableUserInteractionTracing = self.dataProvider.enableUserInteractionTracing
-                options.enableUIViewControllerTracking = self.dataProvider.enableUIViewControllerTracking
+                options.enableUIViewControllerTracing = self.dataProvider.enableUIViewControllerTracking
             #endif
         }
 

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -51,6 +51,11 @@ public extension CrashLoggingDataProvider {
         return config.sampleRate
     }
 
+    var profilingRate: Double {
+        guard case .enabled(let config) = performanceTracking else { return 0.0 }
+        return config.profilingRate
+    }
+
     var enableUIViewControllerTracking: Bool {
         guard case .enabled(let config) = performanceTracking else { return false }
         return config.trackViewControllers

--- a/Sources/Remote Logging/Crash Logging/PerformanceTracking.swift
+++ b/Sources/Remote Logging/Crash Logging/PerformanceTracking.swift
@@ -30,12 +30,18 @@ public enum PerformanceTracking {
         /// – Note: This is only read in iOS, tvOS, and Mac Catalyst clients, i.e. those with UIKit.
         public let trackViewControllers: Bool
 
+        /// The percent of *sampled* transactions that will be included in detailed stack-trace level *profiling*.
+        /// Must be in the range `(0.0)...(1.0)`
+        public let profilingRate: Double
+
         // Compute the sample rate at runtime, to account for it accessing mutable state.
         // Clamp it between 0.0 and 1.0—the values Sentry uses.
         var sampleRate: Double { min(max(sampler(), 0.0), 1.0) }
 
+
         public init(
             sampler: @escaping Sampler = { 0.1 },
+            profilingRate: Double = 0.0,
             trackCoreData: Bool = true,
             trackFileIO: Bool = true,
             trackNetwork: Bool = true,
@@ -43,6 +49,7 @@ public enum PerformanceTracking {
             trackViewControllers: Bool = true
         ) {
             self.sampler = sampler
+            self.profilingRate = min(max(profilingRate, 0.0), 1.0)
             self.trackCoreData = trackCoreData
             self.trackFileIO = trackFileIO
             self.trackNetwork = trackNetwork

--- a/Tests/Tests/PerformanceTrackingTests.swift
+++ b/Tests/Tests/PerformanceTrackingTests.swift
@@ -19,4 +19,14 @@ class PerformanceTrackingTests: XCTestCase {
         XCTAssertEqual(PerformanceTracking.Configuration(sampler: { 1.1 }).sampleRate, 1.0)
         XCTAssertEqual(PerformanceTracking.Configuration(sampler: { 2.0 }).sampleRate, 1.0)
      }
+
+    func testConfigurationProfileRateClamping() {
+        XCTAssertEqual(PerformanceTracking.Configuration(sampler: { 1 }, profilingRate: 0.4).profilingRate, 0.4)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampler: { 1 }, profilingRate: -3).profilingRate, 0.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampler: { 1 }, profilingRate: 0).profilingRate, 0.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampler: { 1 }, profilingRate: 1).profilingRate, 1.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampler: { 1 }, profilingRate: 2).profilingRate, 1.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampler: { 1 }, profilingRate: 5_000).profilingRate, 1.0)
+        XCTAssertEqual(PerformanceTracking.Configuration(sampler: { 1 }, profilingRate: -0.0).profilingRate, 0.0)
+    }
 }


### PR DESCRIPTION
See https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md for details on what's new in Sentry 8.0

Profiling provides [code-level performance profiling](https://docs.sentry.io/product/profiling/), allowing developers to find out exactly which lines of code are slow. At this point, Sentry still calls profiling "Experimental". We'd like to have the option to try it out.


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
