### PR TITLE
Experiment Variation - Return optional instead of `control` 

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '1.0.0'
+  s.version       = '1.1.0-beta'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ _None._
 
 - `logErrorImmediately` and `logErrorsImmediately` no longer have a `Result` parameter in their callback [#232]
 - `logErrorImmediately` and `logErrorsImmediately` no longer `throws` [#236]
+- `ExPlat` returns optional instead of assuming `control` as variant. This lets the client know that there is no variant for an experiment. [#247]
 
 ### New Features
 
@@ -49,3 +50,4 @@ _None._
 
 - Add this changelog file [#234]
 - Log a message if events won't be collected because the user opted out [#239]
+- Make `Variation` confirm to cobable. [#247]

--- a/Sources/Experiments/ABTesting.swift
+++ b/Sources/Experiments/ABTesting.swift
@@ -13,5 +13,5 @@ public protocol ABTesting {
     func refresh(completion: (() -> Void)?)
 
     /// Return an experiment variation
-    func experiment(_ name: String) -> Variation
+    func experiment(_ name: String) -> Variation?
 }

--- a/Sources/Experiments/ABTesting.swift
+++ b/Sources/Experiments/ABTesting.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Variation: Equatable {
+public enum Variation: Equatable, Codable {
     case control
     case treatment
     case customTreatment(name: String)

--- a/Sources/Experiments/ExPlat.swift
+++ b/Sources/Experiments/ExPlat.swift
@@ -95,10 +95,10 @@ import Cocoa
         }
     }
 
-    public func experiment(_ name: String) -> Variation {
+    public func experiment(_ name: String) -> Variation? {
         guard let assignments = UserDefaults.standard.object(forKey: assignmentsKey) as? [String: String?],
               case let variation?? = assignments[name] else {
-            return .control
+            return nil
         }
 
         switch variation {

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"1.0.0";
+NSString *const TracksLibraryVersion = @"1.1.0-beta";

--- a/Tests/Tests/ABTesting/ExPlatTests.swift
+++ b/Tests/Tests/ABTesting/ExPlatTests.swift
@@ -21,7 +21,7 @@ class ExPlatTests: XCTestCase {
         let abTesting = ExPlat(configuration: exPlatTestConfiguration, service: ExPlatServiceMock())
 
         abTesting.refresh {
-            XCTAssertEqual(abTesting.experiment("experiment"), .control)
+            XCTAssertNil(abTesting.experiment("experiment"))
             XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment)
             XCTAssertEqual(abTesting.experiment("experiment_multiple_variation"), .customTreatment(name: "another_treatment"))
             expectation.fulfill()
@@ -70,7 +70,7 @@ class ExPlatTests: XCTestCase {
 
             serviceMock.returnAssignments = false
             abTesting.refresh {
-                XCTAssertEqual(abTesting.experiment("experiment"), .control)
+                XCTAssertNil(abTesting.experiment("experiment"))
                 XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment)
                 XCTAssertEqual(abTesting.experiment("experiment_multiple_variation"), .customTreatment(name: "another_treatment"))
                 expectation.fulfill()


### PR DESCRIPTION
Related to - https://github.com/woocommerce/woocommerce-ios/pull/8806

## Changes
- `ExPlat` returns optional instead of assuming `control` as experiment variation. This lets the client know that there is no variation for an experiment.
- Make `Variation` confirm to codable.

## Why
In WooCommerce iOS, we will cache the variations for the logged-out experiments. We are doing this to try to remove the high crossovers in Abacus that we face for logged-out experiments.

Choosing this solution after exploring other options. More background in https://github.com/woocommerce/woocommerce-ios/pull/8788

## Testing

- CI should pass successfully.
- Test https://github.com/woocommerce/woocommerce-ios/pull/8806

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
