### PR TITLE
Fix the beta version number

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '1.1.0-beta'
+  s.version       = '1.1.0-beta.1'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"1.1.0-beta";
+NSString *const TracksLibraryVersion = @"1.1.0-beta.1";


### PR DESCRIPTION
This PR adds `.1` to the version number.

I missed adding the dot-based version in this PR - https://github.com/Automattic/Automattic-Tracks-iOS/pull/247

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
