### PR TITLE
Bump version number to 2.0.0

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '1.1.0-beta.1'
+  s.version       = '2.0.0-beta.1'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"1.1.0-beta.1";
+NSString *const TracksLibraryVersion = @"2.0.0-beta.1";


### PR DESCRIPTION
The change made in #247 is a breaking change, and I updated the version number from 1.0.0 to 1.1.0. 

The version should be bumped to 2.0.0 instead.

This PR increments the version number to `2.0.0-beta.1`

Internal discussion about bumping the version number for breaking change - p1675371496918299/1675327706.072139-slack-CC7L49W13

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.