### PR TITLE
Bump version from 2.0.0-beta.1 to 2.0.0 stable

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '2.0.0-beta.1'
+  s.version       = '2.0.0'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,7 @@ _None._
 
 ### Breaking Changes
 
-- `logErrorImmediately` and `logErrorsImmediately` no longer have a `Result` parameter in their callback [#232]
-- `logErrorImmediately` and `logErrorsImmediately` no longer `throws` [#236]
-- `ExPlat` returns optional instead of assuming `control` as variant. This lets the client know that there is no variant for an experiment. [#247]
+_None._
 
 ### New Features
 
@@ -48,6 +46,27 @@ _None._
 
 ### Internal Changes
 
+_None._
+
+## [2.0.0](https://github.com/Automattic/Automattic-Tracks-iOS/releases/tag/2.0.0)
+
+### Breaking Changes
+
+- `ExPlat` returns optional instead of assuming `control` as variant. This lets the client know that there is no variant for an experiment. [#247]
+
+### Internal Changes
+
+- Make `Variation` confirm to `Codable`. [#247]
+
+## [1.0.0](https://github.com/Automattic/Automattic-Tracks-iOS/releases/tag/1.0.0)
+
+### Breaking Changes
+
+- `logErrorImmediately` and `logErrorsImmediately` no longer have a `Result` parameter in their callback [#232]
+- `logErrorImmediately` and `logErrorsImmediately` no longer `throws` [#236]
+- `ExPlat` returns optional instead of assuming `control` as variant. This lets the client know that there is no variant for an experiment. [#247]
+
+### Internal Changes
+
 - Add this changelog file [#234]
 - Log a message if events won't be collected because the user opted out [#239]
-- Make `Variation` confirm to cobable. [#247]

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"2.0.0-beta.1";
+NSString *const TracksLibraryVersion = @"2.0.0";


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WooCommerce iOS 12.1 (see https://github.com/woocommerce/woocommerce-ios/pull/8806) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.

cc @spencertransier 