### PR TITLE
Groundwork to support ExPlat in Jetpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _None._
 ### New Features
 
 - The Sentry SDK has been updated to version 8.0.0, and now exposes [Performance Profiling](https://docs.sentry.io/product/profiling/) as an option. [#245]
+- Add a `platform` property to `TracksService` that is used for `ExPlat` configuration. [#253]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-- Refactor `ExPlat` configuration logic to allow clients explicity specify which platform to use. [#253]
+- Refactor `ExPlat` configuration logic to allow clients to explicity specify the platform to use. [#253]
 
 ## 2.1.0
 

--- a/Sources/Event Logging/TracksService.h
+++ b/Sources/Event Logging/TracksService.h
@@ -12,7 +12,7 @@ extern NSString *const TrackServiceDidSendQueuedEventsNotification;
 @property (nonatomic, strong) TracksServiceRemote *remote;
 
 /*! Used to configure the ExPlat `platform` property. If this property is `nil`, the `eventNamePrefix` property is used instead. Default is `nil`. */
-@property (nonatomic, copy, nullable) NSString *platform;
+@property (nonatomic, copy) NSString *platform;
 
 @property (nonatomic, copy) NSString *eventNamePrefix;
 @property (nonatomic, copy) NSString *anonymousUserTypeKey;

--- a/Sources/Event Logging/TracksService.h
+++ b/Sources/Event Logging/TracksService.h
@@ -11,6 +11,9 @@ extern NSString *const TrackServiceDidSendQueuedEventsNotification;
 @property (nonatomic, strong) TracksEventService *tracksEventService;
 @property (nonatomic, strong) TracksServiceRemote *remote;
 
+/*! Used to configure the ExPlat `platform` property. If this property is `nil`, the `eventNamePrefix` property is used instead. Default is `nil`. */
+@property (nonatomic, copy, nullable) NSString *platform;
+
 @property (nonatomic, copy) NSString *eventNamePrefix;
 @property (nonatomic, copy) NSString *anonymousUserTypeKey;
 @property (nonatomic, copy) NSString *authenticatedUserTypeKey;

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -83,6 +83,7 @@ NSString *const USER_ID_ANON = @"anonId";
 {
     self = [super init];
     if (self) {
+        _platform = nil;
         _eventNamePrefix = @"wpios";
         _anonymousUserTypeKey = TracksUserTypeAnonymous;
         _authenticatedUserTypeKey = TracksUserTypeAuthenticated;
@@ -229,7 +230,8 @@ NSString *const USER_ID_ANON = @"anonId";
     self.token = token;
 
     #if TARGET_OS_IPHONE
-    [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:token userAgent:self.userAgent anonId:anonymousID];
+    NSString *platform = _platform ? _platform : _eventNamePrefix;
+    [ExPlat configureWithPlatform:platform oAuthToken:token userAgent:self.userAgent anonId:anonymousID];
     #endif
 }
 
@@ -243,7 +245,8 @@ NSString *const USER_ID_ANON = @"anonId";
     self.token = nil;
 
     #if TARGET_OS_IPHONE
-    [ExPlat configureWithPlatform:_eventNamePrefix oAuthToken:nil userAgent:self.userAgent anonId:anonymousID];
+    NSString *platform = _platform ? _platform : _eventNamePrefix;
+    [ExPlat configureWithPlatform:platform oAuthToken:nil userAgent:self.userAgent anonId:anonymousID];
     #endif
 }
 

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -230,8 +230,7 @@ NSString *const USER_ID_ANON = @"anonId";
     self.token = token;
 
     #if TARGET_OS_IPHONE
-    NSString *platform = _platform ? _platform : _eventNamePrefix;
-    [ExPlat configureWithPlatform:platform oAuthToken:token userAgent:self.userAgent anonId:anonymousID];
+    [ExPlat configureWithPlatform:[self platformForExPlat] oAuthToken:token userAgent:self.userAgent anonId:anonymousID];
     #endif
 }
 
@@ -245,8 +244,7 @@ NSString *const USER_ID_ANON = @"anonId";
     self.token = nil;
 
     #if TARGET_OS_IPHONE
-    NSString *platform = _platform ? _platform : _eventNamePrefix;
-    [ExPlat configureWithPlatform:platform oAuthToken:nil userAgent:self.userAgent anonId:anonymousID];
+    [ExPlat configureWithPlatform:[self platformForExPlat] oAuthToken:nil userAgent:self.userAgent anonId:anonymousID];
     #endif
 }
 
@@ -260,6 +258,11 @@ NSString *const USER_ID_ANON = @"anonId";
     } else {
         [self.timer invalidate];
     }
+}
+
+- (NSString * _Nullable)platformForExPlat
+{
+    return _platform ? _platform : _eventNamePrefix;
 }
 
 #pragma mark - Reachability

--- a/Sources/Experiments/ExPlat.swift
+++ b/Sources/Experiments/ExPlat.swift
@@ -30,6 +30,26 @@ import Cocoa
         UserDefaults.standard.object(forKey: enrolledKey) != nil
     }
 
+    // MARK: - Configuration Properties
+
+    var platform: String {
+        return service.platform
+    }
+
+    var oAuthToken: String? {
+        return service.oAuthToken
+    }
+
+    var userAgent: String? {
+        return service.userAgent
+    }
+
+    var anonId: String? {
+        return service.anonId
+    }
+
+    // MARK: - Init
+
     public init(configuration: ExPlatConfiguration,
                 service: ExPlatService? = nil) {
         self.service = service ?? ExPlatService(configuration: configuration)

--- a/Tests/Test Helpers/Mocks.swift
+++ b/Tests/Test Helpers/Mocks.swift
@@ -123,3 +123,17 @@ class MockEventLoggingNetworkService: EventLoggingNetworkService {
         shouldSucceed ? completion(.success(Data())) : completion(.failure(MockError.generic))
     }
 }
+
+class MockTracksContextManager: TracksContextManager {
+
+    override init() {
+        super.init()
+        self.persistentStoreCoordinator = Self.makeInMemoryPersistentStoreCoordinator(model: managedObjectModel)
+    }
+
+    private static func makeInMemoryPersistentStoreCoordinator(model: NSManagedObjectModel) -> NSPersistentStoreCoordinator {
+        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
+        _ = try? coordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
+        return coordinator
+    }
+}

--- a/Tests/Tests/ABTesting/ExPlatTests.swift
+++ b/Tests/Tests/ABTesting/ExPlatTests.swift
@@ -119,7 +119,7 @@ class ExPlatTests: XCTestCase {
 
     // Tests ExPlat anonymous configuration using TracksService.
     //
-    func testTracksServiceAnonymousConfiguration() {
+    func testTracksServiceAnonymousConfiguration() throws {
         // Given
         let eventNamePrefix = "wooios"
         let anonymousId = "123"
@@ -131,11 +131,10 @@ class ExPlatTests: XCTestCase {
 
         // Then
 #if os(iOS)
-        let exPlat = ExPlat.shared
-        XCTAssertNotNil(exPlat)
-        XCTAssertEqual(exPlat?.platform, eventNamePrefix)
-        XCTAssertEqual(exPlat?.oAuthToken, nil)
-        XCTAssertEqual(exPlat?.anonId, anonymousId)
+        let exPlat = try XCTUnwrap(ExPlat.shared)
+        XCTAssertEqual(exPlat.platform, eventNamePrefix)
+        XCTAssertEqual(exPlat.oAuthToken, nil)
+        XCTAssertEqual(exPlat.anonId, anonymousId)
 #else
         XCTAssertNil(ExPlat.shared)
 #endif
@@ -143,7 +142,7 @@ class ExPlatTests: XCTestCase {
 
     // Tests ExPlat user authenticated configuration using TracksService.
     //
-    func testTracksServiceUserAuthConfiguration() {
+    func testTracksServiceUserAuthConfiguration() throws {
         // Given
         let username = "foobar"
         let userID = "123"
@@ -159,11 +158,10 @@ class ExPlatTests: XCTestCase {
 
         // Then
 #if os(iOS)
-        let exPlat = ExPlat.shared
-        XCTAssertNotNil(exPlat)
-        XCTAssertEqual(exPlat?.platform, platform)
-        XCTAssertEqual(exPlat?.oAuthToken, wpComToken)
-        XCTAssertEqual(exPlat?.anonId, nil)
+        let exPlat = try XCTUnwrap(ExPlat.shared)
+        XCTAssertEqual(exPlat.platform, platform)
+        XCTAssertEqual(exPlat.oAuthToken, wpComToken)
+        XCTAssertEqual(exPlat.anonId, nil)
 #else
         XCTAssertNil(ExPlat.shared)
 #endif

--- a/Tests/Tests/ABTesting/ExPlatTests.swift
+++ b/Tests/Tests/ABTesting/ExPlatTests.swift
@@ -23,6 +23,10 @@ class ExPlatTests: XCTestCase {
         self.tracksService = TracksService(contextManager: contextManager)
     }
 
+    override func tearDown() {
+        ExPlat.shared = nil
+    }
+
     // Save the returned experiments variation
     //
     func testRefresh() {
@@ -126,11 +130,15 @@ class ExPlatTests: XCTestCase {
         self.tracksService.switchToAnonymousUser(withAnonymousID: anonymousId)
 
         // Then
+#if os(iOS)
         let exPlat = ExPlat.shared
         XCTAssertNotNil(exPlat)
         XCTAssertEqual(exPlat?.platform, eventNamePrefix)
         XCTAssertEqual(exPlat?.oAuthToken, nil)
         XCTAssertEqual(exPlat?.anonId, anonymousId)
+#else
+        XCTAssertNil(ExPlat.shared)
+#endif
     }
 
     // Tests ExPlat user authenticated configuration using TracksService.
@@ -150,11 +158,15 @@ class ExPlatTests: XCTestCase {
         self.tracksService.switchToAuthenticatedUser(withUsername: username, userID: userID, wpComToken: wpComToken, skipAliasEventCreation: skipAliasEventCreation)
 
         // Then
+#if os(iOS)
         let exPlat = ExPlat.shared
         XCTAssertNotNil(exPlat)
         XCTAssertEqual(exPlat?.platform, platform)
         XCTAssertEqual(exPlat?.oAuthToken, wpComToken)
         XCTAssertEqual(exPlat?.anonId, nil)
+#else
+        XCTAssertNil(ExPlat.shared)
+#endif
     }
 }
 

--- a/Tests/Tests/ABTesting/ExPlatTests.swift
+++ b/Tests/Tests/ABTesting/ExPlatTests.swift
@@ -2,17 +2,26 @@ import XCTest
 
 #if SWIFT_PACKAGE
 @testable import AutomatticExperiments
+@testable import AutomatticTracksEvents
 #else
 @testable import AutomatticTracks
 #endif
 
 class ExPlatTests: XCTestCase {
+
     var exPlatTestConfiguration = ExPlatConfiguration(
         platform: "wpios_test",
         oAuthToken: nil,
         userAgent: nil,
         anonId: nil
     )
+
+    var tracksService: TracksService!
+
+    override func setUp() {
+        let contextManager = MockTracksContextManager()
+        self.tracksService = TracksService(contextManager: contextManager)
+    }
 
     // Save the returned experiments variation
     //
@@ -102,6 +111,50 @@ class ExPlatTests: XCTestCase {
         ExPlat.configure(platform: "ios", oAuthToken: nil, userAgent: nil, anonId: nil)
 
         XCTAssertEqual(ExPlat.shared?.experimentNames, ["foo", "bar"])
+    }
+
+    // Tests ExPlat anonymous configuration using TracksService.
+    //
+    func testTracksServiceAnonymousConfiguration() {
+        // Given
+        let eventNamePrefix = "wooios"
+        let anonymousId = "123"
+        self.tracksService.platform = nil
+        self.tracksService.eventNamePrefix = eventNamePrefix
+
+        // When
+        self.tracksService.switchToAnonymousUser(withAnonymousID: anonymousId)
+
+        // Then
+        let exPlat = ExPlat.shared
+        XCTAssertNotNil(exPlat)
+        XCTAssertEqual(exPlat?.platform, eventNamePrefix)
+        XCTAssertEqual(exPlat?.oAuthToken, nil)
+        XCTAssertEqual(exPlat?.anonId, anonymousId)
+    }
+
+    // Tests ExPlat user authenticated configuration using TracksService.
+    //
+    func testTracksServiceUserAuthConfiguration() {
+        // Given
+        let username = "foobar"
+        let userID = "123"
+        let wpComToken = "abc"
+        let platform = "wpios"
+        let eventNamePrefix = "jpios"
+        let skipAliasEventCreation = true
+        self.tracksService.platform = platform
+        self.tracksService.eventNamePrefix = eventNamePrefix
+
+        // When
+        self.tracksService.switchToAuthenticatedUser(withUsername: username, userID: userID, wpComToken: wpComToken, skipAliasEventCreation: skipAliasEventCreation)
+
+        // Then
+        let exPlat = ExPlat.shared
+        XCTAssertNotNil(exPlat)
+        XCTAssertEqual(exPlat?.platform, platform)
+        XCTAssertEqual(exPlat?.oAuthToken, wpComToken)
+        XCTAssertEqual(exPlat?.anonId, nil)
     }
 }
 

--- a/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "dc00a3673e3d313e41326bd53802f757defd0eee",
-          "version": "7.28.0"
+          "revision": "2479b6f7ff69b66bcdea82184d097667e63828ed",
+          "version": "8.5.0"
         }
       },
       {

--- a/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "2479b6f7ff69b66bcdea82184d097667e63828ed",
-          "version": "8.5.0"
+          "revision": "dc00a3673e3d313e41326bd53802f757defd0eee",
+          "version": "7.28.0"
         }
       },
       {


### PR DESCRIPTION
Ref p1682352977248619-slack-C04M1NX8YCR

### Related PRs
This PR is blocking:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/20607
- https://github.com/wordpress-mobile/WordPress-iOS/pull/20590

#### The Problem

ExPlat works in WordPress, but it doesn't in Jetpack. This is because of the following endpoint that only supports WordPress:

```swift
var assignmentsEndpoint: String {
    return "https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/\(platform)"
}
```

The `platform` variable is substituted with `wpios` when running `WordPress` and `jpios` when running Jetpack. The problem is that the Backend doesn't support the `.../assignments/jpios` endpoint.

#### Workaround

The Workaround that's already implemented in Android ( see p1682483378071949/1682352977.248619-slack-C04M1NX8YCR ) is to call `.../assignments/wpios` endpoint even on Jetpack.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.