### PR TITLE
Merge release 2.2.0

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '2.1.0'
+  s.version       = '2.2.0'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,13 @@ _None._
 
 ### Internal Changes
 
-- Refactor `ExPlat` configuration logic to allow clients to explicity specify the platform to use. [#253]
+_None._
+
+## 2.2.0
+
+### Internal Changes
+
+- Refactor `ExPlat` configuration logic to allow clients to explicitly specify the platform to use. [#253]
 
 ## 2.1.0
 

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"2.1.0";
+NSString *const TracksLibraryVersion = @"2.2.0";


### PR DESCRIPTION
This version bump PR is part of the release workflow for WordPress iOS 22.3, in particular to unblock https://github.com/wordpress-mobile/WordPress-iOS/pull/20607, and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.