### PR TITLE
Refactor ExPlat assignments endpoint unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Refactor the unit tests for `ExPlat` assignments request. [#256]
 
 ## 2.2.0
 

--- a/Tests/Tests/ABTesting/ExPlatTests.swift
+++ b/Tests/Tests/ABTesting/ExPlatTests.swift
@@ -136,7 +136,7 @@ class ExPlatTests: XCTestCase {
         } response: { _ in
             return .init(data: Data(), statusCode: 200, headers: nil)
         }
-        
+
         // When
         self.makeSharedExPlat(
             platform: nil,

--- a/Tests/Tests/ABTesting/ExPlatTests.swift
+++ b/Tests/Tests/ABTesting/ExPlatTests.swift
@@ -165,6 +165,41 @@ class ExPlatTests: XCTestCase {
 #else
         XCTAssertNil(ExPlat.shared)
 #endif
+    private func makeTracksService(platform: String?, eventNamePrefix: String?) -> TracksService? {
+        guard let tracksService = TracksService(contextManager: MockTracksContextManager()) else {
+            return nil
+        }
+        tracksService.platform = platform
+        tracksService.eventNamePrefix = eventNamePrefix
+        return tracksService
+    }
+
+    private func makeSharedExPlat(platform: String?, eventNamePrefix: String?, experiment: String, anonId: String?) {
+        self.addTeardownBlock {
+            ExPlat.shared = nil
+        }
+        guard let tracksService = makeTracksService(platform: platform, eventNamePrefix: eventNamePrefix) else {
+            return
+        }
+        tracksService.switchToAnonymousUser(withAnonymousID: anonId)
+        guard let exPlat = ExPlat.shared else {
+            return
+        }
+        exPlat.register(experiments: [experiment])
+    }
+
+    private func makeSharedExPlat(platform: String?, eventNamePrefix: String?, experiment: String) {
+        self.addTeardownBlock {
+            ExPlat.shared = nil
+        }
+        guard let tracksService = makeTracksService(platform: platform, eventNamePrefix: eventNamePrefix) else {
+            return
+        }
+        tracksService.switchToAuthenticatedUser(withUsername: "foobar", userID: "123", wpComToken: "abc", skipAliasEventCreation: true)
+        guard let exPlat = ExPlat.shared else {
+            return
+        }
+        exPlat.register(experiments: [experiment])
     }
 }
 

--- a/Tests/Tests/ABTesting/ExPlatTests.swift
+++ b/Tests/Tests/ABTesting/ExPlatTests.swift
@@ -108,6 +108,7 @@ class ExPlatTests: XCTestCase {
         XCTAssertEqual(ExPlat.shared?.experimentNames, ["foo", "bar"])
     }
 
+#if os(iOS)
     /// Tests the right assignments endpoint is called when ExPlat is configured through `TracksService`.
     ///
     func testAssignmentsEndpointWithAnonymousConfiguration() {
@@ -164,6 +165,7 @@ class ExPlatTests: XCTestCase {
         // Then
         wait(for: [expectation], timeout: 1.0)
     }
+#endif
 
     // MARK: - Helpers
 


### PR DESCRIPTION
This PR is to address the following feedback:

- [Use `OHHTTPStubs` to assert that the ExPlat assignments request contains appropriate values](https://github.com/Automattic/Automattic-Tracks-iOS/pull/253#discussion_r1179889461).
- [Constrain the lifecycle of `trackService` to the test methods](https://github.com/Automattic/Automattic-Tracks-iOS/pull/253#discussion_r1180275582).

---
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
