### PR TITLE
Expose an API to override Sentry's stitchAsyncCode option

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -36,6 +36,6 @@ Pod::Spec.new do |s|
   s.module_name = 'AutomatticTracks'
 
   s.ios.dependency 'UIDeviceIdentifier', '~> 2.0'
-  s.dependency 'Sentry', '8.5.0'
+  s.dependency 'Sentry', '8.6.0'
   s.dependency 'Sodium', '>= 0.9.1'
 end

--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -36,6 +36,6 @@ Pod::Spec.new do |s|
   s.module_name = 'AutomatticTracks'
 
   s.ios.dependency 'UIDeviceIdentifier', '~> 2.0'
-  s.dependency 'Sentry', '~> 8.0'
+  s.dependency 'Sentry', '8.5.0'
   s.dependency 'Sodium', '>= 0.9.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Expose a Sentry option to improve the capture of async code stack traces. [#260]
 
 ### Bug Fixes
 

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         //
         // When changing these, make sure to update the matching declaration in
         // the `podspec` file.
-        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", .exact("8.5.0")),
+        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", .exact("8.6.0")),
         .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium", from: "0.9.1"),
         .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.0.0"),
         // Tests dependencies

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         //
         // When changing these, make sure to update the matching declaration in
         // the `podspec` file.
-        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "8.0.0"),
+        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", .exact("8.5.0")),
         .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium", from: "0.9.1"),
         .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.0.0"),
         // Tests dependencies

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -63,7 +63,7 @@ public class CrashLogging {
 
             /// Attach stack traces to non-fatal errors
             options.attachStacktrace = true
-            options.swiftAsyncStacktraces = self.dataProvider.swiftAsyncStacktraces
+            options.stitchAsyncCode = self.dataProvider.enhancedAsyncStacktraces
 
             // Performance monitoring options
             options.enableAutoPerformanceTracing = self.dataProvider.enableAutoPerformanceTracking

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -63,6 +63,7 @@ public class CrashLogging {
 
             /// Attach stack traces to non-fatal errors
             options.attachStacktrace = true
+            options.swiftAsyncStacktraces = self.dataProvider.swiftAsyncStacktraces
 
             // Performance monitoring options
             options.enableAutoPerformanceTracing = self.dataProvider.enableAutoPerformanceTracking

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -7,6 +7,7 @@ import AutomatticTracksModel
 public protocol CrashLoggingDataProvider {
     var sentryDSN: String { get }
     var userHasOptedOut: Bool { get }
+    var swiftAsyncStacktraces: Bool { get }
     var buildType: String { get }
     var releaseName: String { get }
     var currentUser: TracksUser? { get }
@@ -27,6 +28,10 @@ public extension CrashLoggingDataProvider {
     }
 
     var shouldEnableAutomaticSessionTracking: Bool {
+        return false
+    }
+
+    var swiftAsyncStacktraces: Bool {
         return false
     }
 

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -7,7 +7,7 @@ import AutomatticTracksModel
 public protocol CrashLoggingDataProvider {
     var sentryDSN: String { get }
     var userHasOptedOut: Bool { get }
-    var swiftAsyncStacktraces: Bool { get }
+    var enhancedAsyncStacktraces: Bool { get }
     var buildType: String { get }
     var releaseName: String { get }
     var currentUser: TracksUser? { get }
@@ -31,7 +31,7 @@ public extension CrashLoggingDataProvider {
         return false
     }
 
-    var swiftAsyncStacktraces: Bool {
+    var enhancedAsyncStacktraces: Bool {
         return false
     }
 

--- a/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "2479b6f7ff69b66bcdea82184d097667e63828ed",
-          "version": "8.5.0"
+          "revision": "e6dcfba32f2861438b82c7ad34e058b23c83daf6",
+          "version": "8.6.0"
         }
       },
       {


### PR DESCRIPTION
Ref p1687271187638419-slack-C05CANZ2B6F

As the PR title says, we are adding the `options.stitchAsyncCode` during the Sentry initialization. It is `false` by default but clients can override that option.

This PR is needed for:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/20912

At the time of writing this PR, there is a [newer option](https://github.com/getsentry/sentry-cocoa/pull/3051) in the latest Sentry version 8.8.0, named `swiftAsyncStacktraces`. However, this option didn't provide the expected results in the test cases outlined in https://github.com/wordpress-mobile/WordPress-iOS/pull/20912. In contrast, the `stitchAsyncCode` option delivered better results.

---
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.