### PR TITLE
Add options to config Sentry app hang and HTTP client error tracking

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '2.2.0'
+  s.version       = '2.3.0'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ _None._
 
 -->
 
-## Unreleased
+## 2.3.0
 
 ### Breaking Changes
 
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add options to configure Sentry's app hang and HTTP client error tracking. [#261]
 
 ### Bug Fixes
 

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"2.2.0";
+NSString *const TracksLibraryVersion = @"2.3.0";

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -58,6 +58,8 @@ public class CrashLogging {
             options.environment = self.dataProvider.buildType
             options.releaseName = self.dataProvider.releaseName
             options.enableAutoSessionTracking = self.dataProvider.shouldEnableAutomaticSessionTracking
+            options.enableAppHangTracking = self.dataProvider.enableAppHangTracking
+            options.enableCaptureFailedRequests = self.dataProvider.enableCaptureFailedRequests
 
             options.beforeSend = self.beforeSend
 

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -13,6 +13,10 @@ public protocol CrashLoggingDataProvider {
     var additionalUserData: [String: Any] { get }
     var shouldEnableAutomaticSessionTracking: Bool { get }
     var performanceTracking: PerformanceTracking { get }
+    /// Whether app hang are captured.
+    var enableAppHangTracking: Bool { get }
+    /// Whether HTTP client errors are captured.
+    var enableCaptureFailedRequests: Bool { get }
 }
 
 /// Default implementations of common protocol properties
@@ -79,5 +83,15 @@ public extension CrashLoggingDataProvider {
     var enableUserInteractionTracing: Bool {
         guard case .enabled(let config) = performanceTracking else { return false }
         return config.trackUserInteraction
+    }
+
+    /// App hang tracking is enabled by default.
+    var enableAppHangTracking: Bool {
+        return true
+    }
+
+    /// HTTP client errors are captured by default.
+    var enableCaptureFailedRequests: Bool {
+        return true
     }
 }

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -85,13 +85,13 @@ public extension CrashLoggingDataProvider {
         return config.trackUserInteraction
     }
 
-    /// App hang tracking is enabled by default.
+    /// App hang tracking is disabled by default to avoid unexpected events being tracked.
     var enableAppHangTracking: Bool {
-        return true
+        return false
     }
 
-    /// HTTP client errors are captured by default.
+    /// HTTP client errors are disabled by default to avoid unexpected events being tracked.
     var enableCaptureFailedRequests: Bool {
-        return true
+        return false
     }
 }


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/10372

## Description
Since Sentry v8.0.0, app hang and HTTP client errors are tracked by default. These reports overflow the issue list for WCiOS, so we want to add an option to disable these tracking from our side.

This PR adds new options for `CrashLoggingDataProvider`: `enableAppHangTracking` and `enableCaptureFailedRequests`. These are used to configure relevant Sentry options. They are kept as ~`true`~ `false` by default ~not to affect any existing apps using this dependency~ and other apps can opt in if needed.


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
