### PR TITLE
Fix `TracksLogWarn` messages aren't logged with Cocoapods integration

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '2.3.0'
+  s.version       = '2.4.0'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,24 @@ _None._
 
 -->
 
+## 2.4.0
+
+### Breaking Changes
+
+_None._
+
+### New Features
+
+- `TracksService.trackEventName:withCustomProperties:` now returns a boolean that indicates whether the event creation is successful.
+
+### Bug Fixes
+
+- `TracksLogging` now works when the library is integrated with Cocoapods for internal Tracks error/warning messages.
+
+### Internal Changes
+
+_None._
+
 ## 2.3.0
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ _None._
 
 ### Internal Changes
 
+- `TracksService.trackEventName:withCustomProperties:` now logs the event name when there is a validation error from creating a Tracks event.
+
 _None._
 
 ## 2.3.0

--- a/Sources/Event Logging/TracksEventService.m
+++ b/Sources/Event Logging/TracksEventService.m
@@ -58,7 +58,7 @@
     NSError *error;
     BOOL isValid = [tracksEvent validateObject:&error];
     if (!isValid) {
-        TracksLogWarn(@"Error when validating TracksEvent: %@", error);
+        TracksLogWarn(@"Error when validating TracksEvent %@: %@", name, error);
         return nil;
     }
     

--- a/Sources/Event Logging/TracksService.h
+++ b/Sources/Event Logging/TracksService.h
@@ -35,7 +35,12 @@ extern NSString *const TrackServiceDidSendQueuedEventsNotification;
 - (void)switchToAnonymousUserWithAnonymousID:(NSString *)anonymousID;
 
 - (void)trackEventName:(NSString *)eventName;
-- (void)trackEventName:(NSString *)eventName withCustomProperties:(NSDictionary *)customProperties;
+
+/// Tracks an event with custom properties and returns a boolean that indicates whether the creation is successful.
+/// - Parameters:
+///   - eventName: Name of the event.
+///   - customProperties: Custom event properties whose property name should only have alpha characters and underscores.
+- (BOOL)trackEventName:(NSString *)eventName withCustomProperties:(NSDictionary *)customProperties;
 
 - (void)sendQueuedEvents;
 - (void)clearQueuedEvents;

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -134,19 +134,20 @@ NSString *const USER_ID_ANON = @"anonId";
 }
 
 
-- (void)trackEventName:(NSString *)eventName withCustomProperties:(NSDictionary *)customProperties
+- (BOOL)trackEventName:(NSString *)eventName withCustomProperties:(NSDictionary *)customProperties
 {
     eventName = [NSString stringWithFormat:@"%@_%@", self.eventNamePrefix, eventName];
     
-    [self.tracksEventService createTracksEventWithName:eventName
-                                              username:self.username
-                                                userID:self.userID
-                                             userAgent:self.userAgent
-                                              userType:self.isAnonymous ? TracksEventUserTypeAnonymous : TracksEventUserTypeAuthenticated
-                                             eventDate:[NSDate date]
-                                      customProperties:customProperties
-                                      deviceProperties:[self mutableDeviceProperties]
-                                        userProperties:self.userProperties];
+    TracksEvent * _Nullable event = [self.tracksEventService createTracksEventWithName:eventName
+                                                                            username:self.username
+                                                                              userID:self.userID
+                                                                           userAgent:self.userAgent
+                                                                            userType:self.isAnonymous ? TracksEventUserTypeAnonymous : TracksEventUserTypeAuthenticated
+                                                                           eventDate:[NSDate date]
+                                                                    customProperties:customProperties
+                                                                    deviceProperties:[self mutableDeviceProperties]
+                                                                      userProperties:self.userProperties];
+    return event != nil;
 }
 
 - (NSUInteger)queuedEventCount

--- a/Sources/Model/ObjC/Common/TracksLogging.m
+++ b/Sources/Model/ObjC/Common/TracksLogging.m
@@ -9,7 +9,7 @@ Class<TracksLoggingConfiguration> TracksLoggingClass(void) {
 #if SWIFT_PACKAGE
         Class loggingClass = NSClassFromString(@"AutomatticTracksModel.TracksLogging");
 #else
-        Class loggingClass = NSClassFromString(@"TracksLogging");
+        Class loggingClass = NSClassFromString(@"AutomatticTracks.TracksLogging");
 #endif
         if ([loggingClass conformsToProtocol: @protocol(TracksLoggingConfiguration)]) {
             result = loggingClass;

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"2.3.0";
+NSString *const TracksLibraryVersion = @"2.4.0";


### PR DESCRIPTION
Fixes #262 

## Why

Recently, we noticed a Tracks event wasn't actually tracked due to a validation error that wasn't logged anywhere in the console p1693362956666449/1692625489.705669-slack-C039133E1M3 / https://github.com/woocommerce/woocommerce-ios/issues/10574.

https://github.com/Automattic/Automattic-Tracks-iOS/blob/aad902bf945e7528a00ba5b9c5640974d58ff2fd/Sources/Event%20Logging/TracksEventService.m#L59-L61

Upon inspection, `TracksLoggingClass()` is `nil` when the library is integrated with the client app via Cocoapods:

https://github.com/Automattic/Automattic-Tracks-iOS/blob/aad902bf945e7528a00ba5b9c5640974d58ff2fd/Sources/Model/ObjC/Common/TracksLogging.m#L6-L18

I'm guessing the Cocoapods path wasn't tested, and thus Tracks logging has been disabled for a while.

## How

To fix the `nil` `TracksLoggingClass()`, the logging class was updated to include the module name so that the class can be loaded correctly https://github.com/Automattic/Automattic-Tracks-iOS/commit/7dd7d5dd82f512cec17cef1edef94400e15a35e4.

For easier debugging, the event name is now included in the warning message when there is a validation error creating a Tracks event https://github.com/Automattic/Automattic-Tracks-iOS/commit/bce4ea9845abaedde23f0db7d02721b446f2a580.

To enable the client app to log a different message on Tracks event creation error, a success boolean is returned when creating an event with custom properties https://github.com/Automattic/Automattic-Tracks-iOS/commit/a9bfbbc02049d07cbe7f716bac2a156e7abb694f. The return value is default to be discardable in Objective-C.

## Testing steps

Please follow the testing steps in https://github.com/woocommerce/woocommerce-ios/pull/10577.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
