### PR TITLE
Update `releaseName` default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- The default `releaseName` value now includes the CFBundleIdentifierKey, CFBundleShortVersionString, and CFBundleVersionKey [#267]
 
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ When releasing a new version:
 
 ### Breaking Changes
 
-_None._
+- Sentry: The default `releaseName` value is now the Sentry default of `package@version+build` (e.g. com.bundle.identifier@1.2+1.2.3.4) instead of only providing the `CFBundleVersionKey` [#267]
 
 ### New Features
 
@@ -26,7 +26,7 @@ _None._
 
 ### Internal Changes
 
-- The default `releaseName` value now includes the CFBundleIdentifierKey, CFBundleShortVersionString, and CFBundleVersionKey [#267]
+_None._
 
 -->
 

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -56,7 +56,6 @@ public class CrashLogging {
             options.diagnosticLevel = .error
 
             options.environment = self.dataProvider.buildType
-            options.releaseName = self.dataProvider.releaseName
             options.enableAutoSessionTracking = self.dataProvider.shouldEnableAutomaticSessionTracking
             options.enableAppHangTracking = self.dataProvider.enableAppHangTracking
             options.enableCaptureFailedRequests = self.dataProvider.enableCaptureFailedRequests

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -22,11 +22,6 @@ public protocol CrashLoggingDataProvider {
 /// Default implementations of common protocol properties
 public extension CrashLoggingDataProvider {
 
-    // According to https://docs.sentry.io/platforms/apple/configuration/releases/:
-    // "If no release name is set, the SDK creates a default combined from CFBundleIdentifier,
-    // CFBundleShortVersionString, and CFBundleVersion, for example my.project.name@2.3.12+1234"
-    //
-    // Clients can set a custom releaseName value if needed
     var releaseName: String {
         let bundleVersion = Bundle.main.infoDictionary?[kCFBundleVersionKey as String] ?? ""
         let bundleIdentifier = Bundle.main.infoDictionary?[kCFBundleIdentifierKey as String] ?? ""

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -23,11 +23,11 @@ public protocol CrashLoggingDataProvider {
 public extension CrashLoggingDataProvider {
 
     // According to https://docs.sentry.io/platforms/apple/configuration/releases/:
-    // "If no release name is set, the SDK creates a default combined from CFBundleIdentifier, 
+    // "If no release name is set, the SDK creates a default combined from CFBundleIdentifier,
     // CFBundleShortVersionString, and CFBundleVersion, for example my.project.name@2.3.12+1234"
     //
     // Clients can set a custom releaseName value if needed
-    var releaseName: String? = nil
+    var releaseName: String?
 
     var additionalUserData: [String: Any] {
         return [ : ]

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -29,7 +29,7 @@ public extension CrashLoggingDataProvider {
     // Clients can set a custom releaseName value if needed
     var releaseName: String {
         let bundleVersion = Bundle.main.infoDictionary?[kCFBundleVersionKey as String] ?? ""
-        let bundleIdentifer = Bundle.main.infoDictionary?[kCFBundleIdentifierKey as String] ?? ""
+        let bundleIdentifier = Bundle.main.infoDictionary?[kCFBundleIdentifierKey as String] ?? ""
         let bundleShortVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
 
         // This is the format that Sentry recommends for version numbers.

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -27,7 +27,9 @@ public extension CrashLoggingDataProvider {
     // CFBundleShortVersionString, and CFBundleVersion, for example my.project.name@2.3.12+1234"
     //
     // Clients can set a custom releaseName value if needed
-    var releaseName: String?
+    var releaseName: String? {
+        return ""
+    }
 
     var additionalUserData: [String: Any] {
         return [ : ]

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -8,7 +8,6 @@ public protocol CrashLoggingDataProvider {
     var sentryDSN: String { get }
     var userHasOptedOut: Bool { get }
     var buildType: String { get }
-    var releaseName: String { get }
     var currentUser: TracksUser? { get }
     var additionalUserData: [String: Any] { get }
     var shouldEnableAutomaticSessionTracking: Bool { get }

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -22,16 +22,6 @@ public protocol CrashLoggingDataProvider {
 /// Default implementations of common protocol properties
 public extension CrashLoggingDataProvider {
 
-    var releaseName: String {
-        let bundleVersion = Bundle.main.infoDictionary?[kCFBundleVersionKey as String] ?? ""
-        let bundleIdentifier = Bundle.main.infoDictionary?[kCFBundleIdentifierKey as String] ?? ""
-        let bundleShortVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
-
-        // This is the format that Sentry recommends for version numbers.
-        // See https://docs.sentry.io/platforms/apple/configuration/releases/#bind-the-version
-        return "\(bundleIdentifier)@\(bundleShortVersion)+\(bundleVersion)"
-    }
-
     var additionalUserData: [String: Any] {
         return [ : ]
     }

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -22,9 +22,12 @@ public protocol CrashLoggingDataProvider {
 /// Default implementations of common protocol properties
 public extension CrashLoggingDataProvider {
 
-    var releaseName: String {
-        return Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as! String
-    }
+    // According to https://docs.sentry.io/platforms/apple/configuration/releases/:
+    // "If no release name is set, the SDK creates a default combined from CFBundleIdentifier, 
+    // CFBundleShortVersionString, and CFBundleVersion, for example my.project.name@2.3.12+1234"
+    //
+    // Clients can set a custom releaseName value if needed
+    var releaseName: String? = nil
 
     var additionalUserData: [String: Any] {
         return [ : ]

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -27,8 +27,14 @@ public extension CrashLoggingDataProvider {
     // CFBundleShortVersionString, and CFBundleVersion, for example my.project.name@2.3.12+1234"
     //
     // Clients can set a custom releaseName value if needed
-    var releaseName: String? {
-        return nil
+    var releaseName: String {
+        let bundleVersion = Bundle.main.infoDictionary?[kCFBundleVersionKey as String] ?? ""
+        let bundleIdentifer = Bundle.main.infoDictionary?[kCFBundleIdentifierKey as String] ?? ""
+        let bundleShortVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+
+        // This is the format that Sentry recommends for version numbers.
+        // See https://docs.sentry.io/platforms/apple/configuration/releases/#bind-the-version
+        return "\(bundleIdentifier)@\(bundleShortVersion)+\(bundleVersion)"
     }
 
     var additionalUserData: [String: Any] {

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -28,7 +28,7 @@ public extension CrashLoggingDataProvider {
     //
     // Clients can set a custom releaseName value if needed
     var releaseName: String? {
-        return ""
+        return nil
     }
 
     var additionalUserData: [String: Any] {

--- a/TracksDemo/TracksDemo.xcodeproj/project.pbxproj
+++ b/TracksDemo/TracksDemo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/TracksDemo/TracksDemo.xcodeproj/project.pbxproj
+++ b/TracksDemo/TracksDemo.xcodeproj/project.pbxproj
@@ -570,7 +570,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1.0.0.0;
 				GCC_PREFIX_HEADER = TracksDemo/TracksDemo_Prefix.pch;
 				INFOPLIST_FILE = TracksDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -578,7 +577,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.automattic.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -594,7 +592,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1.0.0.0;
 				GCC_PREFIX_HEADER = TracksDemo/TracksDemo_Prefix.pch;
 				INFOPLIST_FILE = TracksDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -602,7 +599,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.automattic.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";

--- a/TracksDemo/TracksDemo.xcodeproj/project.pbxproj
+++ b/TracksDemo/TracksDemo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -570,6 +570,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1.0.0.0;
 				GCC_PREFIX_HEADER = TracksDemo/TracksDemo_Prefix.pch;
 				INFOPLIST_FILE = TracksDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -577,6 +578,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.automattic.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -592,6 +594,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1.0.0.0;
 				GCC_PREFIX_HEADER = TracksDemo/TracksDemo_Prefix.pch;
 				INFOPLIST_FILE = TracksDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -599,6 +602,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.automattic.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";


### PR DESCRIPTION
This PR updates the default `releaseName` attribute from sending only the `CFBundleVersionKey` to now include the `CFBundleIdentifierKey`, `CFBundleShortVersionString`, and `CFBundleVersionKey`. Sentry releases are global across all projects in an organization, so only relying on the `CFBundleVersionKey` was causing conflicts between apps that had the same release number. This will now correctly separate the releases.

The `releaseName` format that we're sending now is the default format that Sentry uses for the `releaseName`. I decided that it would be good to explicitly define that format in this library so that we can ensure future consistency for release names across all the apps. 

I had trouble using the TracksDemo app to test updating the release version in Sentry, so I created a test branch for WooCommerce iOS that points to this dev branch: `test/sentry-release-name` (The only change there is updating the `podfile` to point here)

Using that test branch, I was able to verify that the releases are now being sent up to Sentry with the updated attributes. You can see that the `16.2 (16.2.0.0)` and `16.1 (16.1.0.1)` releases show the full version information now:

<img width="471" alt="Screenshot 2023-11-13 at 4 43 21 PM" src="https://github.com/Automattic/Automattic-Tracks-iOS/assets/17955542/1f1c16d6-55ab-4bf4-916c-c6bb4bb7e96f">



---

- [X] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
