### PR TITLE
Exposing sampleRate parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ _None._
 
 -->
 
+## 3.1.0
+
+### New Features
+
+- CrashLoggingDataProvider now allows to specify the events sampling rate
+
 ## 3.0.0
 
 ### Breaking Changes

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -66,7 +66,7 @@ public class CrashLogging {
             options.attachStacktrace = true
 
             // Events
-            options.sampleRate = NSNumber(value: self.dataProvider.errorEventsSamplingRate)
+            options.sampleRate = NSNumber(value: min(max(self.dataProvider.errorEventsSamplingRate, 0), 1))
 
             // Performance monitoring options
             options.enableAutoPerformanceTracing = self.dataProvider.enableAutoPerformanceTracking

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -66,7 +66,7 @@ public class CrashLogging {
             options.attachStacktrace = true
 
             // Events
-            options.sampleRate = NSNumber(value: self.dataProvider.eventSamplingRate)
+            options.sampleRate = NSNumber(value: self.dataProvider.errorEventsSamplingRate)
 
             // Performance monitoring options
             options.enableAutoPerformanceTracing = self.dataProvider.enableAutoPerformanceTracking

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -65,6 +65,9 @@ public class CrashLogging {
             /// Attach stack traces to non-fatal errors
             options.attachStacktrace = true
 
+            // Events
+            options.sampleRate = NSNumber(value: self.dataProvider.eventSamplingRate)
+
             // Performance monitoring options
             options.enableAutoPerformanceTracing = self.dataProvider.enableAutoPerformanceTracking
             options.tracesSampler = { _ in

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -92,6 +92,6 @@ public extension CrashLoggingDataProvider {
     }
 
     var errorEventsSamplingRate: Double {
-        return 0.01
+        return 1.0
     }
 }

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -10,7 +10,7 @@ public protocol CrashLoggingDataProvider {
     var buildType: String { get }
     var currentUser: TracksUser? { get }
     var additionalUserData: [String: Any] { get }
-    var eventSamplingRate: Double { get }
+    var errorEventsSamplingRate: Double { get }
     var shouldEnableAutomaticSessionTracking: Bool { get }
     var performanceTracking: PerformanceTracking { get }
     /// Whether app hang are captured.
@@ -91,7 +91,7 @@ public extension CrashLoggingDataProvider {
         return false
     }
 
-    var eventSamplingRate: Double {
+    var errorEventsSamplingRate: Double {
         return 0.01
     }
 }

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -10,6 +10,7 @@ public protocol CrashLoggingDataProvider {
     var buildType: String { get }
     var currentUser: TracksUser? { get }
     var additionalUserData: [String: Any] { get }
+    var eventSamplingRate: Double { get }
     var shouldEnableAutomaticSessionTracking: Bool { get }
     var performanceTracking: PerformanceTracking { get }
     /// Whether app hang are captured.
@@ -88,5 +89,9 @@ public extension CrashLoggingDataProvider {
     /// HTTP client errors are disabled by default to avoid unexpected events being tracked.
     var enableCaptureFailedRequests: Bool {
         return false
+    }
+
+    var eventSamplingRate: Double {
+        return 0.01
     }
 }

--- a/Tests/Tests/CrashLoggingTests.swift
+++ b/Tests/Tests/CrashLoggingTests.swift
@@ -130,6 +130,7 @@ class CrashLoggingTests: XCTestCase {
 
     func testPerformanceMonitoringIsDisabledByDefault() {
         let dataProvider = CrashLoggingDataProviderWithDefaultValuesOnly(
+            eventSamplingRate: 0.01,
             sentryDSN: "ignored-in-this-test",
             userHasOptedOut: false,
             buildType: "ignored-in-this-test",
@@ -211,6 +212,7 @@ private class MockCrashLoggingDataProvider: CrashLoggingDataProvider {
     var buildType: String = "test"
     var currentUser: TracksUser? = nil
     var performanceTracking: PerformanceTracking = .disabled
+    var eventSamplingRate: Double = 0.01
 
     func reset() {
         sentryDSN = ""
@@ -223,6 +225,7 @@ private class MockCrashLoggingDataProvider: CrashLoggingDataProvider {
 
 /// Use this to get a `CrashLoggingDataProvider` implementation that allows testing the default values set via protocol extenstion.
 private struct CrashLoggingDataProviderWithDefaultValuesOnly: CrashLoggingDataProvider {
+    var eventSamplingRate: Double
     let sentryDSN: String
     let userHasOptedOut: Bool
     let buildType: String

--- a/Tests/Tests/CrashLoggingTests.swift
+++ b/Tests/Tests/CrashLoggingTests.swift
@@ -225,7 +225,6 @@ private class MockCrashLoggingDataProvider: CrashLoggingDataProvider {
 
 /// Use this to get a `CrashLoggingDataProvider` implementation that allows testing the default values set via protocol extenstion.
 private struct CrashLoggingDataProviderWithDefaultValuesOnly: CrashLoggingDataProvider {
-    var errorEventsSamplingRate: Double
     let sentryDSN: String
     let userHasOptedOut: Bool
     let buildType: String

--- a/Tests/Tests/CrashLoggingTests.swift
+++ b/Tests/Tests/CrashLoggingTests.swift
@@ -130,7 +130,6 @@ class CrashLoggingTests: XCTestCase {
 
     func testPerformanceMonitoringIsDisabledByDefault() {
         let dataProvider = CrashLoggingDataProviderWithDefaultValuesOnly(
-            errorEventsSamplingRate: 0.01,
             sentryDSN: "ignored-in-this-test",
             userHasOptedOut: false,
             buildType: "ignored-in-this-test",
@@ -140,6 +139,8 @@ class CrashLoggingTests: XCTestCase {
         guard case .disabled = dataProvider.performanceTracking else {
             return XCTFail("Expected `CrashLoggingDataProvider` `performanceTracking` to default to `.disabled`. Got \(dataProvider) instead.")
         }
+
+        XCTAssertEqual(dataProvider.errorEventsSamplingRate, 1.0)
     }
 
     func testPerformanceMonitoringConfigurationMappingWhenDisabled() {

--- a/Tests/Tests/CrashLoggingTests.swift
+++ b/Tests/Tests/CrashLoggingTests.swift
@@ -130,7 +130,7 @@ class CrashLoggingTests: XCTestCase {
 
     func testPerformanceMonitoringIsDisabledByDefault() {
         let dataProvider = CrashLoggingDataProviderWithDefaultValuesOnly(
-            eventSamplingRate: 0.01,
+            errorEventsSamplingRate: 0.01,
             sentryDSN: "ignored-in-this-test",
             userHasOptedOut: false,
             buildType: "ignored-in-this-test",
@@ -212,7 +212,7 @@ private class MockCrashLoggingDataProvider: CrashLoggingDataProvider {
     var buildType: String = "test"
     var currentUser: TracksUser? = nil
     var performanceTracking: PerformanceTracking = .disabled
-    var eventSamplingRate: Double = 0.01
+    var errorEventsSamplingRate: Double = 0.01
 
     func reset() {
         sentryDSN = ""
@@ -225,7 +225,7 @@ private class MockCrashLoggingDataProvider: CrashLoggingDataProvider {
 
 /// Use this to get a `CrashLoggingDataProvider` implementation that allows testing the default values set via protocol extenstion.
 private struct CrashLoggingDataProviderWithDefaultValuesOnly: CrashLoggingDataProvider {
-    var eventSamplingRate: Double
+    var errorEventsSamplingRate: Double
     let sentryDSN: String
     let userHasOptedOut: Bool
     let buildType: String


### PR DESCRIPTION
### Details:
In this PR we're enhancing `CrashLoggingDataProvider`: our goal is for the host app to specify the `sampleRate` in which events are uploaded.

We're gonna be using the Events subsystem to track down sync errors (starting at a 1% sample rate).

Thanks in advance!!

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
