### PR TITLE
CrashLogging: New Error Logging API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ _None._
 
 _None._
 
+## 3.2.0
+
+- CrashLogging new API that supports logging Errors with Tag/Value
+
 ## 3.1.0
 
 ### New Features

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -146,7 +146,28 @@ public class CrashLogging {
 // MARK: - Manual Error Logging
 public extension CrashLogging {
 
+    /// Writes the error to the Crash Logging system, and includes a stack trace. This API supports for rich events.
+    /// By setting a Tag/Value pair, you'll be able to filter these events, directly, with the `has:` operator (Sentry Web Interface).
     ///
+    /// - Parameters:
+    ///   - error: The error object
+    ///   - tagName: Tag name to be associated with the error
+    ///   - tagValue: Tag's value to be associated with the error
+    ///   - level: The level of severity to report in Sentry (`.error` by default)
+    func logError(_ error: Error, tagName: String, tagValue: String, level: SentryLevel = .error) {
+
+        let event = Event.from(
+            error: error as NSError,
+            level: level
+        )
+
+        SentrySDK.capture(event: event) { scope in
+            scope.setTag(value: tagValue, key: tagName)
+        }
+
+        dataProvider.didLogErrorCallback?(event)
+    }
+
     /// Writes the error to the Crash Logging system, and includes a stack trace.
     ///
     /// - Parameters:

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -151,8 +151,7 @@ public extension CrashLogging {
     ///
     /// - Parameters:
     ///   - error: The error object
-    ///   - tagName: Tag name to be associated with the error
-    ///   - tagValue: Tag's value to be associated with the error
+    ///   - tags: Tag Key/Value pairs to be set in the Error's Scope
     ///   - level: The level of severity to report in Sentry (`.error` by default)
     func logError(_ error: Error, tags: [String: String], level: SentryLevel = .error) {
 

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -154,7 +154,7 @@ public extension CrashLogging {
     ///   - tagName: Tag name to be associated with the error
     ///   - tagValue: Tag's value to be associated with the error
     ///   - level: The level of severity to report in Sentry (`.error` by default)
-    func logError(_ error: Error, tagName: String, tagValue: String, level: SentryLevel = .error) {
+    func logError(_ error: Error, tags: [String: String], level: SentryLevel = .error) {
 
         let event = Event.from(
             error: error as NSError,
@@ -162,7 +162,9 @@ public extension CrashLogging {
         )
 
         SentrySDK.capture(event: event) { scope in
-            scope.setTag(value: tagValue, key: tagName)
+            for (key, value) in tags {
+                scope.setTag(value: value, key: key)
+            }
         }
 
         dataProvider.didLogErrorCallback?(event)


### PR DESCRIPTION
### Details:

We'll be using Sentry to [track down Sync-Errors in DayOne](https://github.com/bloom/DayOne-Apple/pull/22377). While testing the main integration PR, I've noticed **it was next to impossible** to filter by a given event's **Additional Data** fields. 

You can find a [Sample Event Here](https://a8c.sentry.io/issues/4729708951/?project=5959376&query=user.id%3A1677223025&referrer=issue-stream&statsPeriod=7d&stream_index=2), with the `Additional Data` set (but no Tags)


Since Sentry recommends using Enriched Events, which can then be [filtered with the keyword `has:`.](https://a8c.sentry.io/issues/?project=5959376&query=has%3Async-error&referrer=issue-list&statsPeriod=14d), in this PR we're adding an extra API that allows us to set a `Tag/Value` pair in the event's context.

cc @jkmassel  (Thanks a lot in advance!!

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
