### PR TITLE
Remove `.hound.yml`

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,0 @@
-fail_on_violations: true
-
-swiftlint:
-  config_file: .swiftlint.yml


### PR DESCRIPTION
We have decided to move away from Hound in favor of running our own SwiftLint configuration in CI and, ideally, locally.


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. – N.A.
