### PR TITLE
Add support to log JavaScript exceptions to Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add function to log JavaScript exceptions in `CrashLogging` [#278]
 
 ### Bug Fixes
 

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -152,25 +152,9 @@ public extension CrashLogging {
     /// - Parameters:
     ///   - exception: The exception object
     ///   - callback: Callback triggered upon completion
-    func logJavaScriptException(_ exception: [AnyHashable: Any], callback: @escaping () -> Void) {
-        let jsException = SentryEventJSException.initWithException(exception)
+    func logJavaScriptException(_ jsException: JSException, callback: @escaping () -> Void) {
         
-        if jsException.context == nil {
-            jsException.context = [:]
-        }
-        
-        var reactNativeContext:[String: Any] = exception["context"] as! [String: Any] ?? [:]
-        jsException.context?["react_native_context"] = reactNativeContext;
-        
-        if jsException.tags == nil {
-            jsException.tags = [:]
-        }
-        
-        if exception["tags"] != nil {
-            jsException.tags = jsException.tags?.merging(exception["tags"] as! [String: String]) { $1 }
-        }
-        
-        SentrySDK.capture(event: jsException)
+        SentrySDK.capture(event: SentryEventJSException.initWithException(jsException))
         
         DispatchQueue.global().async {
             SentrySDK.flush(timeout: self.flushTimeout)

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -146,7 +146,13 @@ public class CrashLogging {
 // MARK: - Manual Error Logging
 public extension CrashLogging {
 
-    func logJavaScriptException(_ exception: [AnyHashable: Any]) {
+    /// Writes a JavaScript exception to the Crash Logging system, including its stack trace.
+    /// Note that this function is provided mainly for hybrid sources like React Native.
+    ///
+    /// - Parameters:
+    ///   - exception: The exception object
+    ///   - callback: Callback triggered upon completion
+    func logJavaScriptException(_ exception: [AnyHashable: Any], callback: @escaping () -> Void) {
         let jsException = SentryEventJSException.initWithException(exception)
         
         if jsException.context == nil {
@@ -165,6 +171,11 @@ public extension CrashLogging {
         }
         
         SentrySDK.capture(event: jsException)
+        
+        DispatchQueue.global().async {
+            SentrySDK.flush(timeout: self.flushTimeout)
+            callback()
+        }
     }
     
     /// Writes the error to the Crash Logging system, and includes a stack trace. This API supports for rich events.

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -154,7 +154,7 @@ public extension CrashLogging {
     ///   - callback: Callback triggered upon completion
     func logJavaScriptException(_ jsException: JSException, callback: @escaping () -> Void) {
         
-        SentrySDK.capture(event: SentryEventJSException.initWithException(jsException))
+        SentrySDK.capture(event: SentryEventJSException.init(jsException: jsException))
         
         DispatchQueue.global().async {
             SentrySDK.flush(timeout: self.flushTimeout)

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -152,7 +152,7 @@ public extension CrashLogging {
     /// - Parameters:
     ///   - exception: The exception object
     ///   - callback: Callback triggered upon completion
-    func logJavaScriptException(_ jsException: JSException, callback: @escaping () -> Void) {
+    func logJavaScriptException(_ jsException: any JSException, callback: @escaping () -> Void) {
         
         SentrySDK.capture(event: SentryEventJSException.init(jsException: jsException))
         

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -146,6 +146,27 @@ public class CrashLogging {
 // MARK: - Manual Error Logging
 public extension CrashLogging {
 
+    func logJavaScriptException(_ exception: [AnyHashable: Any]) {
+        let jsException = SentryEventJSException.initWithException(exception)
+        
+        if jsException.context == nil {
+            jsException.context = [:]
+        }
+        
+        var reactNativeContext:[String: Any] = exception["context"] as! [String: Any] ?? [:]
+        jsException.context?["react_native_context"] = reactNativeContext;
+        
+        if jsException.tags == nil {
+            jsException.tags = [:]
+        }
+        
+        if exception["tags"] != nil {
+            jsException.tags = jsException.tags?.merging(exception["tags"] as! [String: String]) { $1 }
+        }
+        
+        SentrySDK.capture(event: jsException)
+    }
+    
     /// Writes the error to the Crash Logging system, and includes a stack trace. This API supports for rich events.
     /// By setting a Tag/Value pair, you'll be able to filter these events, directly, with the `has:` operator (Sentry Web Interface).
     ///

--- a/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
+++ b/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
@@ -44,8 +44,8 @@ public class SentryEventJSException: Event {
         self.platform = "javascript"
     }
     
-    public static func initWithException(_ jsException: JSException) -> SentryEventJSException {
-        let sentryEvent = self.init()
+    public convenience init(jsException: JSException) {
+        self.init()
         
         // Generate exception based on JavaScript exception parameters
         let sentryException = Exception(value: jsException.value, type: jsException.type)
@@ -68,18 +68,16 @@ public class SentryEventJSException: Event {
         sentryException.mechanism = mechanism
         
         // Attach JavaScript exception to Sentry event
-        sentryEvent.exceptions = [sentryException]
+        self.exceptions = [sentryException]
         
         // Set event context
-        var context = sentryEvent.context ?? [:]
+        var context = self.context ?? [:]
         context["react_native_context"] = jsException.context;
-        sentryEvent.context = context
+        self.context = context
         
         // Set event tags
-        let tags = sentryEvent.tags ?? [:]
-        sentryEvent.tags = tags.merging(jsException.tags) { $1 }
-        
-        return sentryEvent
+        let tags = self.tags ?? [:]
+        self.tags = tags.merging(jsException.tags) { $1 }
     }
     
     override public func serialize() -> [String : Any] {

--- a/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
+++ b/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
@@ -3,16 +3,16 @@ import Sentry
 
 public struct JSException {
     public let type: String
-    public let value: String
+    public let message: String
     public let stacktrace: [StacktraceLine]
     public let context: [String: Any]
     public let tags: [String: String]
     public let isHandled: Bool
     public let handledBy: String
 
-    public init(type: String, value: String, stacktrace: [StacktraceLine], context: [String : Any], tags: [String : String], isHandled: Bool, handledBy: String) {
+    public init(type: String, message: String, stacktrace: [StacktraceLine], context: [String : Any], tags: [String : String], isHandled: Bool, handledBy: String) {
         self.type = type
-        self.value = value
+        self.message = message
         self.stacktrace = stacktrace
         self.context = context
         self.tags = tags
@@ -48,7 +48,7 @@ public class SentryEventJSException: Event {
         self.init()
         
         // Generate exception based on JavaScript exception parameters
-        let sentryException = Exception(value: jsException.value, type: jsException.type)
+        let sentryException = Exception(value: jsException.message, type: jsException.type)
         
         // Generate the stacktrace frames
         let frames = jsException.stacktrace.map {

--- a/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
+++ b/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
@@ -1,38 +1,21 @@
 import Foundation
 import Sentry
 
-public struct JSException {
-    public let type: String
-    public let message: String
-    public let stacktrace: [StacktraceLine]
-    public let context: [String: Any]
-    public let tags: [String: String]
-    public let isHandled: Bool
-    public let handledBy: String
+public protocol JSException {
+    var type: String { get }
+    var message: String { get }
+    var jsStacktrace: [StacktraceLine] { get }
+    var context: [String: Any] { get }
+    var tags: [String: String] { get }
+    var isHandled: Bool { get }
+    var handledBy: String { get }
+}
 
-    public init(type: String, message: String, stacktrace: [StacktraceLine], context: [String : Any], tags: [String : String], isHandled: Bool, handledBy: String) {
-        self.type = type
-        self.message = message
-        self.stacktrace = stacktrace
-        self.context = context
-        self.tags = tags
-        self.isHandled = isHandled
-        self.handledBy = handledBy
-    }
-    
-    public struct StacktraceLine {
-        public let filename: String?
-        public let function: String?
-        public let lineno: NSNumber?
-        public let colno: NSNumber?
-        
-        public init(filename: String?, function: String?, lineno: NSNumber?, colno: NSNumber?) {
-            self.filename = filename
-            self.function = function
-            self.lineno = lineno
-            self.colno = colno
-        }
-    }
+public protocol StacktraceLine {
+    var filename: String? { get }
+    var function: String { get }
+    var lineno: NSNumber? { get }
+    var colno: NSNumber? { get }
 }
 
 public class SentryEventJSException: Event {
@@ -51,7 +34,7 @@ public class SentryEventJSException: Event {
         let sentryException = Exception(value: jsException.message, type: jsException.type)
         
         // Generate the stacktrace frames
-        let frames = jsException.stacktrace.map {
+        let frames = jsException.jsStacktrace.map {
             let frame = Frame()
             frame.fileName = $0.filename
             frame.function = $0.function

--- a/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
+++ b/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
@@ -36,7 +36,7 @@ public struct JSException {
 }
 
 public class SentryEventJSException: Event {
-    override required init() {
+    required init() {
         // All JavaScript exceptions should be trated as fatal errors
         super.init(level: .fatal)
         // Setting the event's platform to JavaScript is required by Sentry to be processed
@@ -76,7 +76,7 @@ public class SentryEventJSException: Event {
         sentryEvent.context = context
         
         // Set event tags
-        var tags = sentryEvent.tags ?? [:]
+        let tags = sentryEvent.tags ?? [:]
         sentryEvent.tags = tags.merging(jsException.tags) { $1 }
         
         return sentryEvent

--- a/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
+++ b/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
@@ -1,6 +1,40 @@
 import Foundation
 import Sentry
 
+public struct JSException {
+    public let type: String
+    public let value: String
+    public let stacktrace: [StacktraceLine]
+    public let context: [String: Any]
+    public let tags: [String: String]
+    public let isHandled: Bool
+    public let handledBy: String
+
+    public init(type: String, value: String, stacktrace: [StacktraceLine], context: [String : Any], tags: [String : String], isHandled: Bool, handledBy: String) {
+        self.type = type
+        self.value = value
+        self.stacktrace = stacktrace
+        self.context = context
+        self.tags = tags
+        self.isHandled = isHandled
+        self.handledBy = handledBy
+    }
+    
+    public struct StacktraceLine {
+        public let filename: String?
+        public let function: String?
+        public let lineno: NSNumber?
+        public let colno: NSNumber?
+        
+        public init(filename: String?, function: String?, lineno: NSNumber?, colno: NSNumber?) {
+            self.filename = filename
+            self.function = function
+            self.lineno = lineno
+            self.colno = colno
+        }
+    }
+}
+
 public class SentryEventJSException: Event {
     override required init() {
         // All JavaScript exceptions should be trated as fatal errors.

--- a/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
+++ b/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Sentry
+
+public class SentryEventJSException: Event {
+    override required init() {
+        // All JavaScript exceptions should be trated as fatal errors.
+        super.init(level: .fatal)
+        // Setting the event's platform to JavaScript is required by Sentry to be processed as a JavaScript exception.
+        // Otherwise, Sentry won't symbolicate the stack trace.
+        self.platform = "javascript"
+    }
+    
+    public static func initWithException(_ rawException: [AnyHashable: Any]) -> SentryEventJSException {
+        let sentryEvent = self.init()
+        
+        // Generate exception based on JavaScript exception parameters.
+        let sentryException = Exception(value: rawException["value"] as! String, type: rawException["type"] as! String)
+        
+        // Generate the stacktrace frames.
+        var frames:[Frame] = []
+        let stacktrace = rawException["stacktrace"] as! [[AnyHashable: Any]]
+        for entry in stacktrace {
+            let frame = Frame()
+            frame.fileName = entry["filename"] as! String
+            frame.function = entry["function"] as! String
+            frame.inApp = true
+            frame.lineNumber = entry["lineno"] as? NSNumber ?? 0
+            frame.columnNumber = entry["colno"] as? NSNumber ?? 0
+            frames.append(frame)
+        }
+        sentryException.stacktrace = SentryStacktrace(frames: frames, registers: [:])
+        
+        // Attach JavaScript exception to Sentry event.
+        sentryEvent.exceptions = [sentryException]
+        
+        return sentryEvent
+    }
+    
+    override public func serialize() -> [String : Any] {
+        var serializedData = super.serialize()
+        
+        // By default, events generated in Sentry iOS SDK are tagged to "cocoa" platform.
+        // Hence, we use the original platform set.
+        serializedData["platform"] = self.platform
+        
+        // Removing metadata associated with native exception, as it's not needed for JavaScript exceptions.
+        serializedData["debug_meta"] = nil
+        serializedData["threads"] = nil
+        
+        return serializedData
+    }
+}

--- a/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
+++ b/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
@@ -2,16 +2,17 @@ import Foundation
 import Sentry
 
 public protocol JSException {
+    associatedtype StacktraceLine: JSStacktraceLine
     var type: String { get }
     var message: String { get }
-    var jsStacktrace: [StacktraceLine] { get }
+    var stacktrace: [StacktraceLine] { get }
     var context: [String: Any] { get }
     var tags: [String: String] { get }
     var isHandled: Bool { get }
     var handledBy: String { get }
 }
 
-public protocol StacktraceLine {
+public protocol JSStacktraceLine {
     var filename: String? { get }
     var function: String { get }
     var lineno: NSNumber? { get }
@@ -27,14 +28,14 @@ public class SentryEventJSException: Event {
         self.platform = "javascript"
     }
     
-    public convenience init(jsException: JSException) {
+    public convenience init(jsException: any JSException) {
         self.init()
         
         // Generate exception based on JavaScript exception parameters
         let sentryException = Exception(value: jsException.message, type: jsException.type)
         
         // Generate the stacktrace frames
-        let frames = jsException.jsStacktrace.map {
+        let frames = jsException.stacktrace.map {
             let frame = Frame()
             frame.fileName = $0.filename
             frame.function = $0.function


### PR DESCRIPTION
**Related PRs:**
* https://github.com/WordPress/gutenberg/pull/59221
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6655
* https://github.com/wordpress-mobile/WordPress-iOS/pull/22655

This PR expands the Crash logging service to support logging JavaScript exceptions to Sentry. This will allow hybrid sources like React Native (used in Gutenberg Mobile) to log exceptions with detailed information and symbolicated stack traces, which will greatly simplify the crash debugging process.

The approach is based on previous attempts to log JavaScript exceptions (p9ugOq-249-p2). However, in this case, we are following an SDK-less implementation where the exception is bubbled up to the host app and sent as a Sentry event using the Sentry iOS SDK. As can be seen in the implementation, the Sentry event is adjusted to ensure that Sentry processes it as a JavaScript exception and hence, symbolicate the stack trace with previously uploaded source maps.

The process to log a JavaScript exception has the following steps:
- Gutenberg:
    - [Captures exceptions via error boundary components and a global error handler.](https://github.com/wordpress-mobile/gutenberg-mobile/blob/add/error-boundary/src/errorLogging/index.js)
    - [Parses the exception to convert the format of the stack trace from plain text to an array.](https://github.com/WordPress/gutenberg/blob/rnmobile/add/error-boundary/packages/react-native-bridge/index.js#L537-L591) ([parser](https://github.com/WordPress/gutenberg/blob/rnmobile/add/error-boundary/packages/react-native-bridge/lib/parseException.js))
    - [Sends the parsed exception to the host app (e.g. Jetpack app).](https://github.com/WordPress/gutenberg/blob/rnmobile/add/error-boundary/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift#L430-L441)
 - Host app:
    -  [Logs the JavaScript exception to the Crash logging service.](https://github.com/wordpress-mobile/WordPress-iOS/blob/rnmobile/add/log-exception-to-crash-logging/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift#L1357-L1376)
 - Crash logging service:
    -  [Creates a Sentry event with the JavaScript exception information, ensuring that it will be reported as a JavaScript exception in Sentry.](https://github.com/Automattic/Automattic-Tracks-iOS/blob/add/sentry-js-exception/Sources/Remote%20Logging/Crash%20Logging/SentryEventJSException.swift)

Regarding the source maps, they are uploaded as part of the build process of the host app ([reference](https://github.com/wordpress-mobile/WordPress-iOS/blob/rnmobile/add/log-exception-to-crash-logging/fastlane/lanes/build.rb#L485-L520)).

_More information about this approach is detailed in p9ugOq-4p6-p2._

## To test
Since it involves testing exceptions, we need to modify the code to force them and generate an installable build. A test PR has been created for this purpose, follow the testing instructions from https://github.com/wordpress-mobile/gutenberg-mobile/pull/6654.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.