### PR TITLE
Preserve source compatibility by adding a default value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Fixed source compatibility when upgrading from <3.2 [#279]
 
 ### Internal Changes
 

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -153,7 +153,7 @@ public extension CrashLogging {
     ///   - error: The error object
     ///   - tags: Tag Key/Value pairs to be set in the Error's Scope
     ///   - level: The level of severity to report in Sentry (`.error` by default)
-    func logError(_ error: Error, tags: [String: String], level: SentryLevel = .error) {
+    func logError(_ error: Error, tags: [String: String] = [:], level: SentryLevel = .error) {
 
         let event = Event.from(
             error: error as NSError,


### PR DESCRIPTION
When `logError()` added a required "tags:" parameter in version 3.2.0, this broke source compatibility. Swift Package Manager uses semantic versioning, which means that upgrading from 3.x to 3.y should be source compatible. So lets add a default value so that this can remain source-compatible.


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
