### PR TITLE
Remove two deprecated status bar APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ _None._
 
 ### Internal Changes
 
-_None._
+- The `device_info_status_bar_height` event property value now will always be zero. [#281]
+- Calculate `device_info_orientation` event property value based on "device orientation" rather than "interface orientation". [#281]
 
 ## 3.3.0
 

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -410,7 +410,7 @@ NSString *const USER_ID_ANON = @"anonId";
              DeviceInfoAppleWatchConnectedKey : self.deviceInformation.isAppleWatchConnected ? @"YES" : @"NO",
              DeviceInfoVoiceOverEnabledKey : self.deviceInformation.isVoiceOverEnabled ? @"YES" : @"NO",
              DeviceInfoAppleWatchConnectedKey : self.deviceInformation.isAppleWatchConnected ? @"YES" : @"NO",
-             DeviceInfoStatusBarHeightKey : [NSNumber numberWithFloat:self.deviceInformation.statusBarHeight],
+             DeviceInfoStatusBarHeightKey : @0,
              DeviceInfoOrientation : self.deviceInformation.orientation ?: @"Unknown",
              DeviceInfoPreferredContentSizeCategory : self.deviceInformation.preferredContentSizeCategory ?: @"Unknown",
              DeviceInfoIsAccessibilityCategory : self.deviceInformation.isAccessibilityCategory ? @"YES" : @"NO",

--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.h
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.h
@@ -40,7 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL isOnline;
 @property (nonatomic, assign) BOOL isAppleWatchConnected;
 @property (nonatomic, assign) BOOL isVoiceOverEnabled;
-@property (nonatomic, assign) CGFloat statusBarHeight;
 @property (nonatomic, readonly) NSString *orientation;
 
 @end

--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.m
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.m
@@ -151,7 +151,7 @@
 
 -(NSString *)orientation{
 #if TARGET_OS_IPHONE
-     UIInterfaceOrientation orientation = [self statusBarOrientation];
+     UIDeviceOrientation orientation = [self deviceOrientation];
 
      if (orientation == UIDeviceOrientationPortrait || orientation == UIDeviceOrientationPortraitUpsideDown) {
          return @"Portrait";
@@ -188,18 +188,18 @@
 #endif
 
 #if TARGET_OS_IPHONE
-// This method was created because UIApplication.sharedApplication.statusBarOrientation should only
+// This method was created because UIDevice.currentDevice.orientation should only
 // be called from the main thread.
 //
-- (UIInterfaceOrientation)statusBarOrientation {
+- (UIDeviceOrientation)deviceOrientation {
     if ([NSThread isMainThread]) {
-        return UIApplication.sharedIfAvailable.statusBarOrientation;
+        return UIDevice.currentDevice.orientation;
     }
 
     __block CGFloat orientation = 0;
 
     dispatch_sync(dispatch_get_main_queue(), ^{
-        orientation = UIApplication.sharedIfAvailable.statusBarOrientation;
+        orientation = UIDevice.currentDevice.orientation;
     });
 
     return orientation;

--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.m
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.m
@@ -141,14 +141,6 @@
 #endif
 }
 
--(CGFloat)statusBarHeight{
-#if TARGET_OS_IPHONE
-    return [self statusBarFrame].size.height;
-#else   // Mac
-    return 0;
-#endif
-}
-
 -(NSString *)orientation{
 #if TARGET_OS_IPHONE
      UIDeviceOrientation orientation = [self deviceOrientation];
@@ -166,26 +158,6 @@
 }
 
 #pragma mark - Calls that need to run on the main thread
-
-#if TARGET_OS_IPHONE
-// This method was created because UIApplication.sharedApplication.statusBarFrame should only
-// be called from the main thread.
-//
-- (CGRect)statusBarFrame {
-
-    if ([NSThread isMainThread]) {
-        return UIApplication.sharedIfAvailable.statusBarFrame;
-    }
-
-    __block CGRect frame = CGRectZero;
-
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        frame = UIApplication.sharedIfAvailable.statusBarFrame;
-    });
-
-    return frame;
-}
-#endif
 
 #if TARGET_OS_IPHONE
 // This method was created because UIDevice.currentDevice.orientation should only


### PR DESCRIPTION
Fixes https://github.com/Automattic/Automattic-Tracks-iOS/issues/273.

`UIApplication.statusBarOrientation` is deprecated. Plus, the existing code compares "interface orientation" with `UIDeviceOrientation` which may be problematic.

`UIApplication.statusBarFrame` is also deprecated. I don't imagine we'd care about "status bar" height nowadays. So I have changed the implementation to always return a `0` value.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
