### PR TITLE
TracksDeviceInformation: Caching Device Properties

### DIFF
--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.m
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.m
@@ -194,6 +194,10 @@
 // be called from the main thread.
 //
 - (UIDeviceOrientation)deviceOrientation {
+    if ([NSThread isMainThread]) {
+        self.lastKnownDeviceOrientation = UIDevice.currentDevice.orientation;
+    }
+
     return self.lastKnownDeviceOrientation;
 }
 #endif
@@ -204,6 +208,10 @@
 ///
 - (NSString *)preferredContentSizeCategory {
 #if TARGET_OS_IPHONE
+    if ([NSThread isMainThread]) {
+        self.lastKnownPreferredContentSizeCategory = UIApplication.sharedIfAvailable.preferredContentSizeCategory;
+    }
+
     return self.lastKnownPreferredContentSizeCategory;
 #else   // Mac
     return NULL;
@@ -217,11 +225,12 @@
 ///
 - (BOOL)isAccessibilityCategory {
 #if TARGET_OS_IPHONE
-    if (self.lastKnownPreferredContentSizeCategory == nil) {
+    NSString *preferredCategory = [self preferredContentSizeCategory];
+    if (preferredCategory == nil) {
         return NO;
     }
 
-    return UIContentSizeCategoryIsAccessibilityCategory(self.self.lastKnownPreferredContentSizeCategory);
+    return UIContentSizeCategoryIsAccessibilityCategory(preferredCategory);
 
 #else   // Mac
     return NO;


### PR DESCRIPTION
### Details:
We've observed a deadlock affecting DayOne where:

- The Main thread would run a `performAndWait` invocation against a background Core Data MOC
- A sequence of events would result in a Tracks Event being fired
- And Tracks locking everything up, because the main thread is busy

In this PR we're caching, at launch, the `TracksDeviceProperties`. 

I do realize this approach ain't perfect: Orientation is bond to change, and `preferred content size` could be altered as well. This changeset is *a compromise solution*.

Feedback welcomed, thanks in advance!!