### PR TITLE
Allow SDK consumers to specify release name

### DIFF
--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -56,7 +56,10 @@ public class CrashLogging {
             options.diagnosticLevel = .error
 
             options.environment = self.dataProvider.buildType
-            options.releaseName = self.dataProvider.releaseName
+            switch self.dataProvider.releaseName {
+            case .setByApplication(let name): options.releaseName = name
+            case .setByTracksLibrary: options.releaseName = nil
+            }
             options.enableAutoSessionTracking = self.dataProvider.shouldEnableAutomaticSessionTracking
             options.enableAppHangTracking = self.dataProvider.enableAppHangTracking
             options.enableCaptureFailedRequests = self.dataProvider.enableCaptureFailedRequests

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -56,6 +56,7 @@ public class CrashLogging {
             options.diagnosticLevel = .error
 
             options.environment = self.dataProvider.buildType
+            options.releaseName = self.dataProvider.releaseName
             options.enableAutoSessionTracking = self.dataProvider.shouldEnableAutomaticSessionTracking
             options.enableAppHangTracking = self.dataProvider.enableAppHangTracking
             options.enableCaptureFailedRequests = self.dataProvider.enableCaptureFailedRequests

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -8,6 +8,7 @@ public protocol CrashLoggingDataProvider {
     var sentryDSN: String { get }
     var userHasOptedOut: Bool { get }
     var buildType: String { get }
+    var releaseName: String { get }
     var currentUser: TracksUser? { get }
     var additionalUserData: [String: Any] { get }
     var errorEventsSamplingRate: Double { get }
@@ -21,6 +22,10 @@ public protocol CrashLoggingDataProvider {
 
 /// Default implementations of common protocol properties
 public extension CrashLoggingDataProvider {
+
+    var releaseName: String {
+        return Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as! String
+    }
 
     var additionalUserData: [String: Any] {
         return [ : ]

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -8,7 +8,7 @@ public protocol CrashLoggingDataProvider {
     var sentryDSN: String { get }
     var userHasOptedOut: Bool { get }
     var buildType: String { get }
-    var releaseName: String { get }
+    var releaseName: ReleaseName { get }
     var currentUser: TracksUser? { get }
     var additionalUserData: [String: Any] { get }
     var errorEventsSamplingRate: Double { get }
@@ -20,11 +20,26 @@ public protocol CrashLoggingDataProvider {
     var enableCaptureFailedRequests: Bool { get }
 }
 
+public enum ReleaseName {
+    /**
+     Sets the release name attached for every event sent to Sentry. It's intended to use in debug.
+     - Parameter name: The name of the release.
+     */
+    case setByApplication(name: String)
+    
+    /**
+     Delegates setting the release name to the Tracks library. It's intended to use in release
+     builds. The crash logging framework will single-handedly set the release name based on the
+     build configuration.
+     */
+    case setByTracksLibrary
+}
+
 /// Default implementations of common protocol properties
 public extension CrashLoggingDataProvider {
 
-    var releaseName: String {
-        return Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as! String
+    var releaseName: ReleaseName {
+        return ReleaseName.setByTracksLibrary
     }
 
     var additionalUserData: [String: Any] {


### PR DESCRIPTION
---

Twin PR for Android: https://github.com/Automattic/Automattic-Tracks-Android/pull/206

### Description

Allow SDK consumers to specify release name or that it wants to delegate setting up release name to SDK (it's by default).

### Why?

We would like to decrease a number of "fake releases" (created by running an up from e.g. PR build) to maek Sentry dashboard easier to navigate in. E.g., these highlighted releases are "fake" ones:

![Screenshot 2024-03-25 at 14 11 27](https://github.com/Automattic/Automattic-Tracks-iOS/assets/5845095/cf5dfa99-5790-4ac5-b65a-02bbefa65818)


- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
