### PR TITLE
Use Sentry 8.26.0, compatible with Xcode 15.4

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -36,6 +36,6 @@ Pod::Spec.new do |s|
   s.module_name = 'AutomatticTracks'
 
   s.ios.dependency 'UIDeviceIdentifier', '~> 2.0'
-  s.dependency 'Sentry', '~> 8.0'
+  s.dependency 'Sentry', '~> 8.26'
   s.dependency 'Sodium', '>= 0.9.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Fix Xcode 15.4 compatibility by using Sentry 8.26.0 [#286]
 
 ### Internal Changes
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "c85564d7c92adb28f7ee15e2d758b67d7bfd06bd",
-          "version": "8.3.0"
+          "revision": "7fc7ca43967e2980d8691a8e017c118a84133aac",
+          "version": "8.26.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         //
         // When changing these, make sure to update the matching declaration in
         // the `podspec` file.
-        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "8.0.0"),
+        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "8.26.0"),
         .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium", from: "0.9.1"),
         .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.0.0"),
         // Tests dependencies


### PR DESCRIPTION
What it says in the title. 

I noticed today on Xcode 15.4 that one of our apps using Tracks failed to build 

<img width="1372" alt="image" src="https://github.com/Automattic/Automattic-Tracks-iOS/assets/1218433/08b46438-df99-46b7-a52d-91302f8012d8">

https://github.com/getsentry/sentry-cocoa/pull/3958 fixes the issue and this PR makes use of the version including it in Tracks.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
