### PR TITLE
Expose onCrashedLastRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Exposed Sentry's `onCrashedLastRun` to `CrashLoggingDataProvider`.
 
 ### Bug Fixes
 

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -83,6 +83,8 @@ public class CrashLogging {
                 options.enableUserInteractionTracing = self.dataProvider.enableUserInteractionTracing
                 options.enableUIViewControllerTracing = self.dataProvider.enableUIViewControllerTracking
             #endif
+
+            options.onCrashedLastRun = self.dataProvider.onCrashedLastRun
         }
 
         Internals.crashLogging = self

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Sentry
 
 #if SWIFT_PACKAGE
 import AutomatticTracksModel
@@ -17,6 +18,8 @@ public protocol CrashLoggingDataProvider {
     var enableAppHangTracking: Bool { get }
     /// Whether HTTP client errors are captured.
     var enableCaptureFailedRequests: Bool { get }
+
+    var onCrashedLastRun: ((Event) -> Void)? { get }
 }
 
 /// Default implementations of common protocol properties
@@ -93,5 +96,9 @@ public extension CrashLoggingDataProvider {
 
     var errorEventsSamplingRate: Double {
         return 1.0
+    }
+
+    var onCrashedLastRun: ((Event) -> Void)? {
+        return nil
     }
 }

--- a/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLoggingDataProvider.swift
@@ -19,6 +19,7 @@ public protocol CrashLoggingDataProvider {
     /// Whether HTTP client errors are captured.
     var enableCaptureFailedRequests: Bool { get }
 
+    /// A closure that will run shortly after the crash logging is initialized in case a crash was detected during the previous run.
     var onCrashedLastRun: ((Event) -> Void)? { get }
 }
 

--- a/Tests/Tests/CrashLoggingTests.swift
+++ b/Tests/Tests/CrashLoggingTests.swift
@@ -196,6 +196,12 @@ class CrashLoggingTests: XCTestCase {
             XCTAssertTrue(dataProvider.enableUserInteractionTracing)
         #endif
     }
+
+    func testOnCrashedLastRunDisabledByDefault() {
+        let dataProvider = MockCrashLoggingDataProvider()
+
+        XCTAssertNil(dataProvider.onCrashedLastRun)
+    }
 }
 
 /// Allow throwing Strings as error


### PR DESCRIPTION
This PR exposes Sentry's `onCrashedLastRun` option. This allows us to fetch the crash event on startup.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
