### PR TITLE
Send tracks events in batches of no more than 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ _None._
 ### New Features
 
 - Exposed Sentry's `onCrashedLastRun` to `CrashLoggingDataProvider`.
-- Tracks events are now reported in batches of up to 1000 events, for better performance under large loads.
+- Tracks events are now reported in batches of up to 1000 events, for better performance under large loads. [#293]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _None._
 ### New Features
 
 - Exposed Sentry's `onCrashedLastRun` to `CrashLoggingDataProvider`.
+- Tracks events are now reported in batches of up to 1000 events, for better performance under large loads.
 
 ### Bug Fixes
 

--- a/Sources/Event Logging/TracksEventPersistenceService.h
+++ b/Sources/Event Logging/TracksEventPersistenceService.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)persistTracksEvent:(TracksEvent *)tracksEvent;
 
 - (NSArray *)fetchAllTracksEvents;
+- (NSArray *)fetchTracksEventsWithLimit:(NSInteger)limit;
 
 - (NSUInteger)countAllTracksEvents;
 

--- a/Sources/Event Logging/TracksEventPersistenceService.m
+++ b/Sources/Event Logging/TracksEventPersistenceService.m
@@ -9,6 +9,7 @@
 #endif
 
 @import Foundation;
+@import CoreData;
 
 @interface TracksEventPersistenceService ()
 
@@ -40,7 +41,7 @@
 }
 
 
-- (NSArray *)fetchAllTracksEvents
+- (NSArray *)fetchAllTracksEvents 
 {
     __block NSMutableArray *transformedResults;
     
@@ -64,6 +65,32 @@
     
     return transformedResults;
 }
+
+- (NSArray *)fetchTracksEventsWithLimit:(NSInteger)limit {
+    __block NSMutableArray *transformedResults;
+
+    [self.managedObjectContext performBlockAndWait:^{
+        NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"TracksEvent"];
+        fetchRequest.fetchLimit = limit;
+
+        NSError *error;
+        NSArray *results = [self.managedObjectContext executeFetchRequest:fetchRequest error:&error];
+
+        if (error) {
+            TracksLogError(@"Error while fetching all TracksEvent: %@", error);
+            return;
+        }
+
+        transformedResults = [[NSMutableArray alloc] initWithCapacity:results.count];
+        for (TracksEventCoreData *eventCoreData in results) {
+            TracksEvent *tracksEvent = [self mapToTracksEventWithTracksEventCoreData:eventCoreData];
+            [transformedResults addObject:tracksEvent];
+        }
+    }];
+
+    return transformedResults;
+}
+
 
 
 - (NSUInteger)countAllTracksEvents

--- a/Sources/Event Logging/TracksEventPersistenceService.m
+++ b/Sources/Event Logging/TracksEventPersistenceService.m
@@ -41,7 +41,7 @@
 }
 
 
-- (NSArray *)fetchAllTracksEvents 
+- (NSArray *)fetchAllTracksEvents
 {
     return [self fetchTracksEventsWithLimit:0];
 }
@@ -70,8 +70,6 @@
 
     return transformedResults;
 }
-
-
 
 - (NSUInteger)countAllTracksEvents
 {

--- a/Sources/Event Logging/TracksEventPersistenceService.m
+++ b/Sources/Event Logging/TracksEventPersistenceService.m
@@ -43,27 +43,7 @@
 
 - (NSArray *)fetchAllTracksEvents 
 {
-    __block NSMutableArray *transformedResults;
-    
-    [self.managedObjectContext performBlockAndWait:^{
-        NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"TracksEvent"];
-        
-        NSError *error;
-        NSArray *results = [self.managedObjectContext executeFetchRequest:fetchRequest error:&error];
-        
-        if (error) {
-            TracksLogError(@"Error while fetching all TracksEvent: %@", error);
-            return;
-        }
-        
-        transformedResults = [[NSMutableArray alloc] initWithCapacity:results.count];
-        for (TracksEventCoreData *eventCoreData in results) {
-            TracksEvent *tracksEvent = [self mapToTracksEventWithTracksEventCoreData:eventCoreData];
-            [transformedResults addObject:tracksEvent];
-        }
-    }];
-    
-    return transformedResults;
+    return [self fetchTracksEventsWithLimit:0];
 }
 
 - (NSArray *)fetchTracksEventsWithLimit:(NSInteger)limit {

--- a/Sources/Event Logging/TracksEventService.h
+++ b/Sources/Event Logging/TracksEventService.h
@@ -25,6 +25,7 @@
                                           withAnonymousUserID:(NSString *)anonymousUserID;
 
 - (NSArray *)allTracksEvents;
+- (NSArray *)tracksEventsWithLimit:(NSInteger)limit;
 
 - (NSUInteger)numberOfTracksEvents;
 

--- a/Sources/Event Logging/TracksEventService.m
+++ b/Sources/Event Logging/TracksEventService.m
@@ -97,6 +97,11 @@
     return [self.persistenceService fetchAllTracksEvents];
 }
 
+- (NSArray *)tracksEventsWithLimit:(NSInteger)limit
+{
+    return [self.persistenceService fetchTracksEventsWithLimit:limit];
+}
+
 
 - (void)removeTracksEvents:(NSArray *)tracksEvents
 {

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -161,7 +161,7 @@ NSString *const USER_ID_ANON = @"anonId";
     [self.timer invalidate];
     [[NSNotificationCenter defaultCenter] postNotificationName:TrackServiceWillSendQueuedEventsNotification object:nil];
     
-    NSArray *events = [self.tracksEventService allTracksEvents];
+    NSArray *events = [self.tracksEventService tracksEventsWithLimit:1000];
 
     if (events.count == 0) {
         [self resetTimer];

--- a/Tests/Tests/ObjC/TracksServiceTests.m
+++ b/Tests/Tests/ObjC/TracksServiceTests.m
@@ -101,7 +101,7 @@
     tracksEvent.eventName = @"Test";
     tracksEvent.userID = @"anonymous123";
     NSArray *events = @[tracksEvent];
-    OCMExpect([self.tracksEventService allTracksEvents]).andReturn(events);
+    OCMExpect([self.tracksEventService tracksEventsWithLimit:1000]).andReturn(events);
     
     OCMExpect([self.subject.remote sendBatchOfEvents:[OCMArg checkWithBlock:^BOOL(id obj) {
         XCTAssertTrue([obj isKindOfClass:[NSArray class]]);


### PR DESCRIPTION
When sending tracks events, adds a limit of 1000 events to send per batch.

There are two reasons for this:
- Tracks events are currently being fetched on the main queue, because that's where `-[TracksService sendQueuedEvents]` is being called when the timer goes off. If we fetch an unbounded number of events, it can result in the main thread hanging if there are many tracks events to send.
- The tracks reporting endpoint will reject batches that are too large. Experimentally, I've seen this happen when I tried to send 100k events in a single batch. This would lead to increasingly large event counts on device, as we continued to gather then without ever being able to send them.

With these changes, the UI is much less likely to hang. On my device, fetching a batch of 1000 events took only 0.03s, which is probably acceptable on the main thread. By contrast, fetching 93,000 events took 2.25s, a clearly noticeable hang. (And yes, we have a user who appears to have over 100,000 unsent events. Not sure how.)

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
