### PR TITLE
Use Sentry 8.39.0 to fix SwiftUI previews on Mac

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -36,6 +36,6 @@ Pod::Spec.new do |s|
   s.module_name = 'AutomatticTracks'
 
   s.ios.dependency 'UIDeviceIdentifier', '~> 2.0'
-  s.dependency 'Sentry', '~> 8.29'
+  s.dependency 'Sentry', '~> 8.39'
   s.dependency 'Sodium', '>= 0.9.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
-
+- Fix SwiftUI previews on Mac which broke due to a bug in Sentry [#297]
 
 ### Breaking Changes
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "c9a692ba837f4832ec7ce6378c071cb91cb55f92",
-          "version": "8.29.0"
+          "revision": "0b8ba88f5fd70062887d55f87a970c59b1ceebcf",
+          "version": "8.39.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         //
         // When changing these, make sure to update the matching declaration in
         // the `podspec` file.
-        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "8.29.0"),
+        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "8.39.0"),
         .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium", from: "0.9.1"),
         .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.0.0"),
         // Tests dependencies

--- a/TracksDemo/TracksDemo.xcodeproj/project.pbxproj
+++ b/TracksDemo/TracksDemo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "2479b6f7ff69b66bcdea82184d097667e63828ed",
-          "version": "8.5.0"
+          "revision": "0b8ba88f5fd70062887d55f87a970c59b1ceebcf",
+          "version": "8.39.0"
         }
       },
       {


### PR DESCRIPTION
This Sentry update includes a fix for SwiftUI previews on the Mac platform: https://github.com/getsentry/sentry-cocoa/issues/4350#issuecomment-2399086919.

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
