### PR TITLE
Bump version to 3.5.1

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '3.5.0'
+  s.version       = '3.5.1'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,13 @@ _None._
 
 ### Internal Changes
 
-- Fix SwiftUI previews on Mac which broke due to a bug in Sentry [#297]
-
-### Breaking Changes
-
 _None._
+
+## 3.5.1
+
+### Internal Changes
+
+- Fix SwiftUI previews on Mac which broke due to a bug in Sentry [#297]
 
 ## 3.5.0
 

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"3.5.0";
+NSString *const TracksLibraryVersion = @"3.5.1";


### PR DESCRIPTION
Releases this change: https://github.com/Automattic/Automattic-Tracks-iOS/pull/297.

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
