### PR TITLE
Use ephemeral URLSession to send encrypted logs

### DIFF
--- a/Sources/Encrypted Logs/EventLoggingNetworkService.swift
+++ b/Sources/Encrypted Logs/EventLoggingNetworkService.swift
@@ -6,7 +6,7 @@ class EventLoggingNetworkService {
 
     private let urlSession: URLSession
 
-    init(urlSession: URLSession = URLSession.shared) {
+    init(urlSession: URLSession = URLSession(configuration: .ephemeral)) {
         self.urlSession = urlSession
     }
 

--- a/Sources/Experiments/ExPlatService.swift
+++ b/Sources/Experiments/ExPlatService.swift
@@ -16,6 +16,7 @@ public class ExPlatService {
     let oAuthToken: String?
     let userAgent: String?
     let anonId: String?
+    let urlSession: URLSession
 
     var experimentNames: [String] = []
 
@@ -28,6 +29,7 @@ public class ExPlatService {
         self.oAuthToken = configuration.oAuthToken
         self.userAgent = configuration.userAgent
         self.anonId = configuration.anonId
+        self.urlSession = URLSession(configuration: .ephemeral)
     }
 
     func getAssignments(completion: @escaping (Assignments?) -> Void) {

--- a/Tests/Tests/Event Logging/EventLoggingTests.swift
+++ b/Tests/Tests/Event Logging/EventLoggingTests.swift
@@ -113,3 +113,4 @@ extension EventLoggingTests {
             .withLogUploadUrl(url)
     }
 }
+x

--- a/Tests/Tests/Event Logging/EventLoggingTests.swift
+++ b/Tests/Tests/Event Logging/EventLoggingTests.swift
@@ -113,4 +113,3 @@ extension EventLoggingTests {
             .withLogUploadUrl(url)
     }
 }
-x


### PR DESCRIPTION
No need to send cookies in the shared cookies jar to the encrypted logs endpoint.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
