### PR TITLE
AINFRA-283 - Set `queue: mac` explicitly in pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
+agents:
+  queue: mac
+
 env:
   IMAGE_ID: xcode-15.0.1
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ agents:
   queue: mac
 
 env:
-  IMAGE_ID: xcode-15.0.1
+  IMAGE_ID: xcode-16.4
 
 # Nodes with values to reuse in the pipeline.
 common_params:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ env:
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-    - automattic/a8c-ci-toolkit#3.0.1
+    - automattic/a8c-ci-toolkit#3.5.1
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+env:
+  IMAGE_ID: xcode-15.0.1
+
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
     - automattic/a8c-ci-toolkit#3.0.1
-  # Common environment values to use with the `env` key.
-  env: &common_env
-    IMAGE_ID: xcode-15.0.1
 
 # This is the default pipeline – it will build and test the app
 steps:
@@ -19,7 +22,6 @@ steps:
       # See https://bugs.swift.org/browse/SR-13803
 
       build_and_test_pod ios test || build_and_test_pod ios test
-    env: *common_env
     plugins: *common_plugins
     artifact_paths: ".build/logs/*.log"
 
@@ -34,7 +36,6 @@ steps:
       # See https://bugs.swift.org/browse/SR-13803
 
       build_and_test_pod mac test || build_and_test_pod mac test
-    env: *common_env
     plugins: *common_plugins
     artifact_paths: ".build/logs/*.log"
 
@@ -45,7 +46,6 @@ steps:
     key: "validate"
     command: |
       validate_podspec --patch-cocoapods
-    env: *common_env
     plugins: *common_plugins
     artifact_paths: ".build/logs/*.log"
 
@@ -55,7 +55,6 @@ steps:
   - label: "🔬 Validating Version"
     key: "version_check"
     command: .buildkite/check-version-consistency.sh
-    env: *common_env
     plugins: *common_plugins
 
   #################
@@ -65,7 +64,6 @@ steps:
     key: "lint"
     command: |
       lint_pod
-    env: *common_env
     plugins: *common_plugins
 
   #################
@@ -74,7 +72,6 @@ steps:
   - label: "⬆️ Publish Podspec"
     key: "publish"
     command: .buildkite/publish-pod.sh
-    env: *common_env
     plugins: *common_plugins
     depends_on:
       - "test_ios"


### PR DESCRIPTION
This will allow adopting an improved default pipeline upload step on the CI infrastructure side of the setup. It also makes it clear what queue is in use just by looking at the pipeline file.

Notice it does not introduce the standard `shared-pipeline-vars` file because to use that we first need the default pipeline upload step in the IaC configuration.

See https://linear.app/a8c/issue/AINFRA-283

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. – N.A.
