### PR TITLE
Add device name and OS to UserAgent string for iOS

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '3.5.2'
+  s.version       = '3.5.3'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 3.5.3
+
+### Internal Changes
+
+- Differentiate between iOS and iPadOS in `userAgent` sent with the events
+
 ## 3.5.2
 
 ### Internal Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ _None._
 
 ### Internal Changes
 
-- Differentiate between iOS and iPadOS in `userAgent` sent with the events
+- Differentiate between iOS and iPadOS in `userAgent` sent with the events [#303]
 
 ## 3.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ _None._
 
 ### Internal Changes
 
-- Differentiate between iOS and iPadOS in `userAgent` sent with the events [#303]
+- Send device model and OS with UserAgent string [#303]
 
 ## 3.5.2
 

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -477,6 +477,7 @@ NSString *const USER_ID_ANON = @"anonId";
         NSString *osVersion = self.deviceInformation.version;
         return [NSString stringWithFormat:@"Nosara Client %@ for %@, %@:%@", TracksLibraryVersion, deviceModel, osName, osVersion];
     #endif
+
     #if TARGET_OS_MAC
         return [NSString stringWithFormat:@"Nosara Client for macOS %@", TracksLibraryVersion];
     #endif

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -472,7 +472,13 @@ NSString *const USER_ID_ANON = @"anonId";
 - (NSString *)userAgent
 {
     #if TARGET_OS_IPHONE
-        return [NSString stringWithFormat:@"Nosara Client for iOS %@", TracksLibraryVersion];
+        NSString *osName = @"iOS";
+        if (@available(iOS 13.0, *)) {
+            if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+                osName = @"iPadOS";
+            }
+        }
+        return [NSString stringWithFormat:@"Nosara Client for %@ %@", osName, TracksLibraryVersion];
     #endif
 
     #if TARGET_OS_MAC

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -472,7 +472,7 @@ NSString *const USER_ID_ANON = @"anonId";
 - (NSString *)userAgent
 {
     #if TARGET_OS_IPHONE
-        NSString *deviceModel = self.deviceInformation.device_info_model;
+        NSString *deviceModel = self.deviceInformation.model;
         NSString *osName = self.deviceInformation.os;
         NSString *osVersion = self.deviceInformation.version;
         return [NSString stringWithFormat:@"Nosara Client %@ for %@, %@:%@", TracksLibraryVersion, deviceModel, osName, osVersion];

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -476,6 +476,7 @@ NSString *const USER_ID_ANON = @"anonId";
         NSString *osName = self.deviceInformation.os;
         NSString *osVersion = self.deviceInformation.version;
         return [NSString stringWithFormat:@"Nosara Client %@ for %@, %@:%@", TracksLibraryVersion, deviceModel, osName, osVersion];
+    #endif
     #if TARGET_OS_MAC
         return [NSString stringWithFormat:@"Nosara Client for macOS %@", TracksLibraryVersion];
     #endif

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -472,15 +472,10 @@ NSString *const USER_ID_ANON = @"anonId";
 - (NSString *)userAgent
 {
     #if TARGET_OS_IPHONE
-        NSString *osName = @"iOS";
-        if (@available(iOS 13.0, *)) {
-            if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
-                osName = @"iPadOS";
-            }
-        }
-        return [NSString stringWithFormat:@"Nosara Client for %@ %@", osName, TracksLibraryVersion];
-    #endif
-
+        NSString *deviceModel = self.deviceInformation.device_info_model;
+        NSString *osName = self.deviceInformation.os;
+        NSString *osVersion = self.deviceInformation.version;
+        return [NSString stringWithFormat:@"Nosara Client %@ for %@, %@:%@", TracksLibraryVersion, deviceModel, osName, osVersion];
     #if TARGET_OS_MAC
         return [NSString stringWithFormat:@"Nosara Client for macOS %@", TracksLibraryVersion];
     #endif

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"3.5.2";
+NSString *const TracksLibraryVersion = @"3.5.3";


### PR DESCRIPTION
This is part of a project to [improve device detection for Tracks events](https://nosaraproject.wordpress.com/2024/07/16/question-data-factoring-in-mobile/). In this PR, we update the `userAgent` sent with Tracks event to identify he device and OS.


- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
