### PR TITLE
Update UserAgent to be backward compatible

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Automattic-Tracks-iOS'
-  s.version       = '3.5.3'
+  s.version       = '3.5.4'
 
   s.summary       = 'Simple way to track events in an iOS app with Automattic Tracks internal service'
   s.description   = <<-DESC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ _None._
 
 - Make user agent compatible with existing values [#304]
 
-### 3.5.3
+## 3.5.3
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,13 @@ _None._
 
 _None._
 
-## 3.5.3
+## 3.5.4
+
+### Internal Changes
+
+- Make user agent compatible with existing values [#304]
+
+### 3.5.3
 
 ### Internal Changes
 

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -475,7 +475,7 @@ NSString *const USER_ID_ANON = @"anonId";
         NSString *deviceModel = self.deviceInformation.model;
         NSString *osName = self.deviceInformation.os;
         NSString *osVersion = self.deviceInformation.version;
-        return [NSString stringWithFormat:@"Nosara Client %@ for %@, %@:%@", TracksLibraryVersion, deviceModel, osName, osVersion];
+        return [NSString stringWithFormat:@"Nosara Client for %@; %@/%@; %@", deviceModel, osName, osVersion, TracksLibraryVersion];
     #endif
 
     #if TARGET_OS_MAC

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,4 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"3.5.3";
+NSString *const TracksLibraryVersion = @"3.5.4";


### PR DESCRIPTION
@crazytonyli [pointed](https://a8c.slack.com/archives/C04PWEZSYFL/p1757473563890549?thread_ts=1757407299.676829&cid=C04PWEZSYFL) that the UserAgent strings from https://github.com/Automattic/Automattic-Tracks-iOS/pull/303 were not compitble with existing configs

This PR updates it to be backward compatible. It also switches to `;` and `/` as delimiter within the UserAgent string to simplify parsing.

Tested that new agents are fine with :

```
(venv) anandnalya@hiyu:~$ curl -A "Nosara Client for iPhone17,1; iOS/18.6.2; 3.3.2" https://public-api.wordpress.com -I
HTTP/1.1 200 Connection Established
Via: HTTP/1.1 fp.jump-a07-48.hiyu.hadoop.dfw.wordpress.com

HTTP/2 302 
server: nginx
date: Wed, 10 Sep 2025 06:19:38 GMT
content-type: text/html; charset=utf-8
location: https://developer.wordpress.com/docs/api/
x-ac: 2.dfw _dfw BYPASS
alt-svc: clear
strict-transport-security: max-age=31536000
server-timing: a8c-cdn, dc;desc=dfw, cache;desc=BYPASS;dur=1.0

(venv) anandnalya@hiyu:~$ curl -A "Nosara Client for iPhone SE 3rd-gen; iOS/18.6.2; 3.3.2" https://public-api.wordpress.com -I
HTTP/1.1 200 Connection Established
Via: HTTP/1.1 fp.jump-a06-48.hiyu.hadoop.dfw.wordpress.com

HTTP/2 302 
server: nginx
date: Wed, 10 Sep 2025 06:21:17 GMT
content-type: text/html; charset=utf-8
location: https://developer.wordpress.com/docs/api/
x-ac: 2.dfw _dfw BYPASS
alt-svc: clear
strict-transport-security: max-age=31536000
server-timing: a8c-cdn, dc;desc=dfw, cache;desc=BYPASS;dur=1.0

(venv) anandnalya@hiyu:~$ curl -A "Nosara Client for MacBookAir9,1; OS X/15.4.1; 3.3.2" https://public-api.wordpress.com -I
HTTP/1.1 200 Connection Established
Via: HTTP/1.1 fp.jump-a06-48.hiyu.hadoop.dfw.wordpress.com

HTTP/2 302 
server: nginx
date: Wed, 10 Sep 2025 06:24:08 GMT
content-type: text/html; charset=utf-8
location: https://developer.wordpress.com/docs/api/
x-ac: 2.dfw _dfw BYPASS
alt-svc: clear
strict-transport-security: max-age=31536000
server-timing: a8c-cdn, dc;desc=dfw, cache;desc=BYPASS;dur=1.0
```
---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
