### PR TITLE
Add event props validation for reserved names and type

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -36,6 +36,7 @@ Pod::Spec.new do |s|
   s.module_name = 'AutomatticTracks'
 
   s.ios.dependency 'UIDeviceIdentifier', '~> 2.0'
-  s.dependency 'Sentry', '~> 8.39'
+  # See https://linear.app/a8c/project/upgrade-sentry-cocoa-to-9x-0ecbf7d5a91e
+  s.dependency 'Sentry', '~> 8.39', '< 8.49.0'
   s.dependency 'Sodium', '>= 0.9.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Constrained version to `< 8.49.0` for CocoaPods installations to avoid deprecation warnings till we upgrade Sentry to version 9.x [#310]
 
 ## 3.5.4
 

--- a/Sources/Model/ObjC/Common/TracksEvent.m
+++ b/Sources/Model/ObjC/Common/TracksEvent.m
@@ -1,6 +1,6 @@
 #import "TracksEvent.h"
 
-static NSArray<NSString *> * kReservedNames;
+static NSSet<NSString *> * kReservedNames;
 
 @implementation TracksEvent
 
@@ -10,7 +10,7 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
 + (void)initialize {
     if (self == [TracksEvent class]) {
         // Reserved property names defined here: https://github.com/Automattic/nosara/blob/master/ganymedes2/kafka_staging/src/main/scala/com/automattic/ganymedes2/streaming/tracks/schema/TracksEvent.scala
-        kReservedNames = @[    @"timestamp",
+        kReservedNames = [NSSet setWithArray: @[    @"timestamp",
                                   @"year",
                                   @"month",
                                   @"day",
@@ -54,7 +54,7 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
                                   @"etlmessage",
                                   @"eventmarker",
                                   @"record_ymdh"
-        ];
+        ]];
     }
 }
 
@@ -335,13 +335,7 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
 
 - (BOOL)checkPropertyNameIsReserved:(NSString *)propertyName
 {
-    for (NSString *name in kReservedNames) {
-        if ([propertyName isEqualToString:name]) {
-            return YES;
-        }
-    }
-
-    return NO;
+    return [kReservedNames containsObject:propertyName];
 }
 
 - (BOOL)checkPropertyTypeIsValid:(id) type

--- a/Sources/Model/ObjC/Common/TracksEvent.m
+++ b/Sources/Model/ObjC/Common/TracksEvent.m
@@ -9,7 +9,7 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
 
 + (void)initialize {
     if (self == [TracksEvent class]) {
-        // List of reserved Property names that is defined here: https://github.com/Automattic/nosara/blob/master/ganymedes2/kafka_staging/src/main/scala/com/automattic/ganymedes2/streaming/tracks/schema/TracksEvent.scala
+        // Reserved property names defined here: https://github.com/Automattic/nosara/blob/master/ganymedes2/kafka_staging/src/main/scala/com/automattic/ganymedes2/streaming/tracks/schema/TracksEvent.scala
         kReservedNames = @[    @"timestamp",
                                   @"year",
                                   @"month",

--- a/Sources/Model/ObjC/Common/TracksEvent.m
+++ b/Sources/Model/ObjC/Common/TracksEvent.m
@@ -214,11 +214,11 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
 
             if ([self checkPropertyNameIsReserved:key] == YES) {
                 if (outError != NULL) {
-                    NSString *errorString = NSLocalizedString(@"User properties dictionary key is reserved on Server",
-                                                              @"validation: TracksEvent, key format userProperties error");
+                    NSString *errorString = [NSString stringWithFormat: NSLocalizedString(@"User properties dictionary key [%@] is reserved on Server",
+                                                              @"validation: TracksEvent, key format userProperties error"), key];
                     NSDictionary *userInfoDict = @{ NSLocalizedDescriptionKey : errorString };
                     *outError = [[NSError alloc] initWithDomain:TracksErrorDomain
-                                                           code:TracksErrorCodeValidationUserPropertiesKeyFormat
+                                                           code:TracksErrorCodeValidationUserPropertiesKeyReservedWord
                                                        userInfo:userInfoDict];
                 }
 
@@ -227,11 +227,11 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
 
             if ([self checkPropertyTypeIsValid:dict[key]] == NO) {
                 if (outError != NULL) {
-                    NSString *errorString = NSLocalizedString(@"User properties dictionary value is not a valid type. It must be an String, Int or Boolean",
-                                                              @"validation: TracksEvent, value format userProperties error");
+                    NSString *errorString = [NSString stringWithFormat: NSLocalizedString(@"User properties dictionary value for [%@] is not a valid type. It must be an String, Int or Boolean",
+                                                              @"validation: TracksEvent, value format userProperties error"), key];
                     NSDictionary *userInfoDict = @{ NSLocalizedDescriptionKey : errorString };
                     *outError = [[NSError alloc] initWithDomain:TracksErrorDomain
-                                                           code:TracksErrorCodeValidationUserPropertiesKeyFormat
+                                                           code:TracksErrorCodeValidationUserPropertiesInvalidType
                                                        userInfo:userInfoDict];
                 }
 

--- a/Sources/Model/ObjC/Common/TracksEvent.m
+++ b/Sources/Model/ObjC/Common/TracksEvent.m
@@ -10,6 +10,7 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
 
 + (void)initialize {
     if (self == [TracksEvent class]) {
+        // List of reserved Property names that is defined here: https://github.com/Automattic/nosara/blob/master/ganymedes2/kafka_staging/src/main/scala/com/automattic/ganymedes2/streaming/tracks/schema/TracksEvent.scala
         kReservedNames = @[    @"timestamp",
                                   @"year",
                                   @"month",

--- a/Sources/Model/ObjC/Common/TracksEvent.m
+++ b/Sources/Model/ObjC/Common/TracksEvent.m
@@ -226,7 +226,7 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
 
             if ([self checkPropertyTypeIsValid:dict[key]] == NO) {
                 if (outError != NULL) {
-                    NSString *errorString = [NSString stringWithFormat: NSLocalizedString(@"User properties dictionary value for [%@] is not a valid type. It must be an String, Int or Boolean",
+                    NSString *errorString = [NSString stringWithFormat: NSLocalizedString(@"Custom properties dictionary value for [%@] is not a valid type. It must be a String, Int or Boolean",
                                                               @"validation: TracksEvent, value format userProperties error"), key];
                     NSDictionary *userInfoDict = @{ NSLocalizedDescriptionKey : errorString };
                     *outError = [[NSError alloc] initWithDomain:TracksErrorDomain

--- a/Sources/Model/ObjC/Common/TracksEvent.m
+++ b/Sources/Model/ObjC/Common/TracksEvent.m
@@ -213,11 +213,11 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
 
             if ([self checkPropertyNameIsReserved:key] == YES) {
                 if (outError != NULL) {
-                    NSString *errorString = [NSString stringWithFormat: NSLocalizedString(@"User properties dictionary key [%@] is reserved on Server",
-                                                              @"validation: TracksEvent, key format userProperties error"), key];
+                    NSString *errorString = [NSString stringWithFormat: NSLocalizedString(@"Custom properties dictionary key [%@] is reserved on Server",
+                                                              @"validation: TracksEvent, key format customProperties error"), key];
                     NSDictionary *userInfoDict = @{ NSLocalizedDescriptionKey : errorString };
                     *outError = [[NSError alloc] initWithDomain:TracksErrorDomain
-                                                           code:TracksErrorCodeValidationUserPropertiesKeyReservedWord
+                                                           code:TracksErrorCodeValidationCustomPropertiesKeyReservedWord
                                                        userInfo:userInfoDict];
                 }
 
@@ -227,10 +227,10 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
             if ([self checkPropertyTypeIsValid:dict[key]] == NO) {
                 if (outError != NULL) {
                     NSString *errorString = [NSString stringWithFormat: NSLocalizedString(@"Custom properties dictionary value for [%@] is not a valid type. It must be a String, Int or Boolean",
-                                                              @"validation: TracksEvent, value format userProperties error"), key];
+                                                              @"validation: TracksEvent, value format customProperties error"), key];
                     NSDictionary *userInfoDict = @{ NSLocalizedDescriptionKey : errorString };
                     *outError = [[NSError alloc] initWithDomain:TracksErrorDomain
-                                                           code:TracksErrorCodeValidationUserPropertiesInvalidType
+                                                           code:TracksErrorCodeValidationCustomPropertiesInvalidType
                                                        userInfo:userInfoDict];
                 }
 

--- a/Sources/Model/ObjC/Common/TracksEvent.m
+++ b/Sources/Model/ObjC/Common/TracksEvent.m
@@ -1,9 +1,62 @@
 #import "TracksEvent.h"
 
+static NSArray<NSString *> * kReservedNames;
+
+
 @implementation TracksEvent
 
 NSString *const TracksEventNameRegExPattern = @"^(([a-z0-9]+)_){2}([a-z0-9_]+)$";
 NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
+
++ (void)initialize {
+    if (self == [TracksEvent class]) {
+        kReservedNames = @[    @"timestamp",
+                                  @"year",
+                                  @"month",
+                                  @"day",
+                                  @"dateymd",
+                                  @"datetime",
+                                  @"logdateymd",
+                                  @"anonid",
+                                  @"userid",
+                                  @"useridtype",
+                                  @"userlang",
+                                  @"eventnamepartial",
+                                  @"eventname",
+                                  @"eventprops",
+                                  @"eventsource",
+                                  @"geoip",
+                                  @"geocountrycode",
+                                  @"geocountry",
+                                  @"georegion",
+                                  @"geocity",
+                                  @"geolatitude",
+                                  @"geolongitude",
+                                  @"logdate",
+                                  @"logtimestamp",
+                                  @"logmethod",
+                                  @"logreferrer",
+                                  @"requesttimestamp",
+                                  @"eventtimestamp",
+                                  @"browserlang",
+                                  @"browserfamilyversion",
+                                  @"browserfamily",
+                                  @"browserdocumentlocation",
+                                  @"browserdocumentreferrer",
+                                  @"useragent",
+                                  @"devicefamily",
+                                  @"deviceos",
+                                  @"blogid",
+                                  @"bloglang",
+                                  @"blogtimezone",
+                                  @"kafkatopic",
+                                  @"processingtimestamp",
+                                  @"etlmessage",
+                                  @"eventmarker",
+                                  @"record_ymdh"
+        ];
+    }
+}
 
 - (instancetype)init
 {
@@ -157,6 +210,32 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
                 
                 return NO;
             }
+
+            if ([self checkPropertyNameIsReserved:key] == YES) {
+                if (outError != NULL) {
+                    NSString *errorString = NSLocalizedString(@"User properties dictionary key is reserved on Server",
+                                                              @"validation: TracksEvent, key format userProperties error");
+                    NSDictionary *userInfoDict = @{ NSLocalizedDescriptionKey : errorString };
+                    *outError = [[NSError alloc] initWithDomain:TracksErrorDomain
+                                                           code:TracksErrorCodeValidationUserPropertiesKeyFormat
+                                                       userInfo:userInfoDict];
+                }
+
+                return NO;
+            }
+
+            if ([self checkPropertyTypeIsValid:dict[key]] == NO) {
+                if (outError != NULL) {
+                    NSString *errorString = NSLocalizedString(@"User properties dictionary value is not a valid type. It must be an String, Int or Boolean",
+                                                              @"validation: TracksEvent, value format userProperties error");
+                    NSDictionary *userInfoDict = @{ NSLocalizedDescriptionKey : errorString };
+                    *outError = [[NSError alloc] initWithDomain:TracksErrorDomain
+                                                           code:TracksErrorCodeValidationUserPropertiesKeyFormat
+                                                       userInfo:userInfoDict];
+                }
+
+                return NO;
+            }
         }
         
         return YES;
@@ -253,6 +332,31 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
 
     return matches.count > 0;
 }
+
+- (BOOL)checkPropertyNameIsReserved:(NSString *)propertyName
+{
+    for (NSString *name in kReservedNames) {
+        if ([propertyName isEqualToString:name]) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+- (BOOL)checkPropertyTypeIsValid:(id) type
+{
+    if ([type isKindOfClass:[NSString class]]) {
+        return YES;
+    }
+
+    if ([type isKindOfClass:[NSNumber class]]) {
+        return YES;
+    }
+
+    return NO;
+}
+
 
 //@property (nonatomic, copy) NSString *username;
 //@property (nonatomic, copy) NSString *userID;

--- a/Sources/Model/ObjC/Common/TracksEvent.m
+++ b/Sources/Model/ObjC/Common/TracksEvent.m
@@ -2,7 +2,6 @@
 
 static NSArray<NSString *> * kReservedNames;
 
-
 @implementation TracksEvent
 
 NSString *const TracksEventNameRegExPattern = @"^(([a-z0-9]+)_){2}([a-z0-9_]+)$";
@@ -357,7 +356,6 @@ NSString *const TracksPropertiesKeyRegExPattern = @"^[a-z][a-z0-9_]*$";
 
     return NO;
 }
-
 
 //@property (nonatomic, copy) NSString *username;
 //@property (nonatomic, copy) NSString *userID;

--- a/Sources/Model/ObjC/Constants/TracksConstants.h
+++ b/Sources/Model/ObjC/Constants/TracksConstants.h
@@ -18,5 +18,8 @@ typedef NS_ENUM(NSInteger, TracksErrorCode) {
     TracksErrorRemoteResponseError,
 
     TracksErrorFileMissing,
-    TracksErrorOperationCancelled
+    TracksErrorOperationCancelled,
+
+    TracksErrorCodeValidationUserPropertiesKeyReservedWord,
+    TracksErrorCodeValidationUserPropertiesInvalidType
 };

--- a/Sources/Model/ObjC/Constants/TracksConstants.h
+++ b/Sources/Model/ObjC/Constants/TracksConstants.h
@@ -20,6 +20,6 @@ typedef NS_ENUM(NSInteger, TracksErrorCode) {
     TracksErrorFileMissing,
     TracksErrorOperationCancelled,
 
-    TracksErrorCodeValidationUserPropertiesKeyReservedWord,
-    TracksErrorCodeValidationUserPropertiesInvalidType
+    TracksErrorCodeValidationCustomPropertiesKeyReservedWord,
+    TracksErrorCodeValidationCustomPropertiesInvalidType
 };

--- a/Tests/Tests/ObjC/TracksEventTests.m
+++ b/Tests/Tests/ObjC/TracksEventTests.m
@@ -166,7 +166,7 @@
     XCTAssertFalse(valid);
     XCTAssertNotNil(error);
     XCTAssertEqual(error.domain, TracksErrorDomain);
-    XCTAssertEqual(TracksErrorCodeValidationUserPropertiesKeyReservedWord, error.code);
+    XCTAssertEqual(TracksErrorCodeValidationCustomPropertiesKeyReservedWord, error.code);
 }
 
 - (void)testCustomPropertiesInvalidPropertyInvalidValue
@@ -181,7 +181,7 @@
     XCTAssertFalse(valid);
     XCTAssertNotNil(error);
     XCTAssertEqual(error.domain, TracksErrorDomain);
-    XCTAssertEqual(TracksErrorCodeValidationUserPropertiesInvalidType, error.code);
+    XCTAssertEqual(TracksErrorCodeValidationCustomPropertiesInvalidType, error.code);
 }
 
 

--- a/Tests/Tests/ObjC/TracksEventTests.m
+++ b/Tests/Tests/ObjC/TracksEventTests.m
@@ -154,6 +154,37 @@
     XCTAssertEqual(TracksErrorCodeValidationCustomPropertiesKeyFormat, error.code);
 }
 
+- (void)testCustomPropertiesInvalidPropertyReservedKey
+{
+    NSError *error;
+    NSMutableDictionary *customProperties = self.subject.customProperties;
+    customProperties[@"year"] = @"2025";
+
+    BOOL valid = [self.subject validateValue:&customProperties forKey:@"customProperties" error:&error];
+
+    XCTAssertNotNil(customProperties);
+    XCTAssertFalse(valid);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.domain, TracksErrorDomain);
+    XCTAssertEqual(TracksErrorCodeValidationUserPropertiesKeyReservedWord, error.code);
+}
+
+- (void)testCustomPropertiesInvalidPropertyInvalidValue
+{
+    NSError *error;
+    NSMutableDictionary *customProperties = self.subject.customProperties;
+    customProperties[@"categories"] = @[@2025, @2024];
+
+    BOOL valid = [self.subject validateValue:&customProperties forKey:@"customProperties" error:&error];
+
+    XCTAssertNotNil(customProperties);
+    XCTAssertFalse(valid);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.domain, TracksErrorDomain);
+    XCTAssertEqual(TracksErrorCodeValidationUserPropertiesInvalidType, error.code);
+}
+
+
 - (void)testDevicePropertiesNoProperties
 {
     NSError *error;


### PR DESCRIPTION
This PR adds two new validation of event properties:

- Check if the property name is not a [reserved name on Tracks](https://github.com/Automattic/nosara/blob/master/ganymedes2/kafka_staging/src/main/scala/com/automattic/ganymedes2/streaming/tracks/schema/TracksEvent.scala)
- Check if  the property type is supported by Tracks

One doubt that I have is should this PR reject events based on the rules above, or just emit a console warning. Please advice.

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
