### PR TITLE
Use up-to-date API for deprecated Sentry `profilesSampleRate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Replace deprecated `profilesSampleRate` usage with recommended `configureProfiling -> sessionSampleRate` [#309]
 
 ## 3.5.4
 

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -75,7 +75,10 @@ public class CrashLogging {
                 // input `SamplingContext` down the chain.
                 NSNumber(value: self.dataProvider.tracesSampler())
             }
-            options.profilesSampleRate = NSNumber(value: self.dataProvider.profilingRate)
+            options.configureProfiling = { [weak self] in
+              guard let self else { return }
+              $0.sessionSampleRate = Float(self.dataProvider.profilingRate)
+            }
             options.enableNetworkTracking = self.dataProvider.enableNetworkTracking
             options.enableFileIOTracing = self.dataProvider.enableFileIOTracking
             options.enableCoreDataTracing = self.dataProvider.enableCoreDataTracking


### PR DESCRIPTION
<!-- blue -->
> [!NOTE]  
> Closed in favor of #310. As you can see in CI, this change satisfies the CocoaPods validation but breaks the Swift build. That's because we track the `Package.resolved` file for the SwiftPM installation, and the Sentry version there does not result in the deprecation warning nor has the new API that should be used instaed.
>
> Rather than going down the update rabbit hole in the context of shipping #307, I tracked a project to address it in isolation https://linear.app/a8c/project/upgrade-sentry-cocoa-to-9x-0ecbf7d5a91e/overview

Discovered this while looking at the CI podspec validation in https://github.com/Automattic/Automattic-Tracks-iOS/pull/307.

See
https://buildkite.com/automattic/tracks-ios/builds/567/steps/canvas?jid=019b6982-8d11-4849-bc9b-8f520a104b27#019b6982-8d11-4849-bc9b-8f520a104b27/L3836


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
