### PR TITLE
Constrain Sentry version to less than 8.49 for CocoaPods

### DIFF
--- a/Automattic-Tracks-iOS.podspec
+++ b/Automattic-Tracks-iOS.podspec
@@ -36,6 +36,7 @@ Pod::Spec.new do |s|
   s.module_name = 'AutomatticTracks'
 
   s.ios.dependency 'UIDeviceIdentifier', '~> 2.0'
-  s.dependency 'Sentry', '~> 8.39'
+  # See https://linear.app/a8c/project/upgrade-sentry-cocoa-to-9x-0ecbf7d5a91e
+  s.dependency 'Sentry', '~> 8.39', '< 8.49.0'
   s.dependency 'Sodium', '>= 0.9.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Constrained version to `< 8.49.0` for CocoaPods installations to avoid deprecation warnings till we upgrade Sentry to version 9.x [#310]
 
 ## 3.5.4
 


### PR DESCRIPTION

<!-- yellow -->
> [!WARNING]  
> Update: This change has been superseded by #311 

---

See https://linear.app/a8c/issue/AINFRA-1676 related to the library validation error revealed by
https://github.com/Automattic/Automattic-Tracks-iOS/pull/307: https://buildkite.com/automattic/tracks-ios/builds/567/steps/canvas?jid=019b6982-8d11-4849-bc9b-8f520a104b27#019b6982-8d11-4849-bc9b-8f520a104b27/L3836

Notice `podspec` validation passes in this PR. 

I didn't spend extra time on this right now because the issue is only just a deprecation warning _and_ the constraint affects only CocoaPods installations, which we support for the sake of it but none of our clients use.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
