### PR TITLE
PR to identify which SwiftLint version broke the Liner agent 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,36 +14,6 @@ common_params:
 
 # This is the default pipeline – it will build and test the app
 steps:
-  ######################
-  # Build and Test iOS
-  ######################
-  - label: "🧪 Build and Test iOS"
-    key: "test_ios"
-    command: |
-      install_gems
-      bundle exec fastlane ios test
-    plugins: *common_plugins
-    artifact_paths: ".build/logs/*.log"
-
-  ######################
-  # Build and Test macOS
-  ######################
-  - label: "🧪 Build and Test macOS"
-    key: "test_macos"
-    command: |
-      install_gems
-      bundle exec fastlane mac test
-    plugins: *common_plugins
-    artifact_paths: ".build/logs/*.log"
-
-  #################
-  # Check Version Consistency
-  #################
-  - label: "🔬 Validating Version"
-    key: "version_check"
-    command: .buildkite/check-version-consistency.sh
-    plugins: *common_plugins
-
   - label: ":swift: SwiftLint"
     command: swiftlint
     agents:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -47,8 +47,8 @@ only_rules:
 
 # Rules configuration
 
-control_statement: 
-  severity: error 
+control_statement:
+  severity: error
 
 custom_rules:
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-swiftlint_version: 0.59.1
+swiftlint_version: 0.60.0
 
 excluded:
   - .build

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-swiftlint_version: 0.58.2
+swiftlint_version: 0.59.1
 
 excluded:
   - .build


### PR DESCRIPTION
Quickly identified the first failing version as [0.60.0](https://github.com/realm/SwiftLint/releases/tag/0.60.0).

<img width="949" height="49" alt="image" src="https://github.com/user-attachments/assets/0bb2554d-9fdd-4501-8b93-778f82bb85f7" />
<img width="958" height="63" alt="image" src="https://github.com/user-attachments/assets/3abdc211-4052-4fbf-bdda-d953526d6707" />

