### PR TITLE
Remove Tracks version from User Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ _None._
 
 ### Breaking Changes
 
-_None._
+- The library no longer includes its version in the User Agent used to send event to the server. [#313]
 
 ### New Features
 

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -475,14 +475,14 @@ NSString *const USER_ID_ANON = @"anonId";
         NSString *deviceModel = self.deviceInformation.model;
         NSString *osName = self.deviceInformation.os;
         NSString *osVersion = self.deviceInformation.version;
-        return [NSString stringWithFormat:@"Nosara Client for %@; %@/%@; %@", deviceModel, osName, osVersion, TracksLibraryVersion];
+        return [NSString stringWithFormat:@"Nosara Client for %@; %@/%@", deviceModel, osName, osVersion];
     #endif
 
     #if TARGET_OS_MAC
-        return [NSString stringWithFormat:@"Nosara Client for macOS %@", TracksLibraryVersion];
+        return [NSString stringWithFormat:@"Nosara Client for macOS"];
     #endif
 
-    return [NSString stringWithFormat:@"Nosara Client for Objective-C %@", TracksLibraryVersion];
+    return [NSString stringWithFormat:@"Nosara Client for Objective-C"];
 }
 
 @end

--- a/Sources/Model/ObjC/Constants/TracksConstants.h
+++ b/Sources/Model/ObjC/Constants/TracksConstants.h
@@ -1,7 +1,6 @@
 #import <Foundation/Foundation.h>
 
 FOUNDATION_EXPORT NSString *const TracksErrorDomain;
-FOUNDATION_EXPORT NSString *const TracksLibraryVersion;
 
 typedef NS_ENUM(NSInteger, TracksErrorCode) {
     TracksErrorCodeValidationEventNameMissing,

--- a/Sources/Model/ObjC/Constants/TracksConstants.m
+++ b/Sources/Model/ObjC/Constants/TracksConstants.m
@@ -1,4 +1,3 @@
 #import "TracksConstants.h"
 
 NSString *const TracksErrorDomain = @"TracksErrorDomain";
-NSString *const TracksLibraryVersion = @"3.5.4";


### PR DESCRIPTION
This has been discussed internally and we decided that the overhead of keeping the version in sync between code and Git tags was not worth the value of tracking it in the user agent.

Given we already track the version of the app that logs events via the library, the library's version can always be deduced.

See https://linear.app/a8c/issue/AINFRA-1698/remove-version-from-user-agent

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
