### PR TITLE
Update sentry to version 9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- The Sentry version used is now 9.4.0 [#315]
 
 ## 4.0.0
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "0b8ba88f5fd70062887d55f87a970c59b1ceebcf",
-          "version": "8.39.0"
+          "revision": "f1eefffd88cd6dfe5751159a3b32ff3c8e5b3b32",
+          "version": "9.4.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "AutomatticTracksiOS",
-    platforms: [.macOS(.v10_14), .iOS(.v13)],
+    platforms: [.macOS(.v10_14), .iOS(.v15)],
     products: [
         .library(
             name: "AutomatticTracks",
@@ -30,7 +30,7 @@ let package = Package(
     ],
     dependencies: [
         // Runtime dependencies
-        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "8.39.0"),
+        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "9.1.0"),
         .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium", from: "0.9.1"),
         .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.0.0"),
         // Tests dependencies

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     ],
     dependencies: [
         // Runtime dependencies
-        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "9.1.0"),
+        .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "9.4.0"),
         .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium", from: "0.9.1"),
         .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.0.0"),
         // Tests dependencies

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -75,7 +75,10 @@ public class CrashLogging {
                 // input `SamplingContext` down the chain.
                 NSNumber(value: self.dataProvider.tracesSampler())
             }
-            options.profilesSampleRate = NSNumber(value: self.dataProvider.profilingRate)
+            options.configureProfiling = { [weak self] in
+                guard let self else { return }
+                $0.sessionSampleRate = Float(self.dataProvider.profilingRate)
+            }
             options.enableNetworkTracking = self.dataProvider.enableNetworkTracking
             options.enableFileIOTracing = self.dataProvider.enableFileIOTracking
             options.enableCoreDataTracing = self.dataProvider.enableCoreDataTracking

--- a/Tests/Tests/CrashLoggingTests.swift
+++ b/Tests/Tests/CrashLoggingTests.swift
@@ -28,7 +28,7 @@ class CrashLoggingTests: XCTestCase {
             _ = try CrashLogging(dataProvider: mockDataProvider).start()
             XCTFail("The call above should fail")
         } catch let err {
-            XCTAssertEqual("Project ID path component of DSN is missing", err.localizedDescription)
+            XCTAssertEqual("URL scheme of DSN is missing", err.localizedDescription)
         }
     }
 

--- a/TracksDemo/TracksDemo.xcodeproj/project.pbxproj
+++ b/TracksDemo/TracksDemo.xcodeproj/project.pbxproj
@@ -572,7 +572,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_PREFIX_HEADER = TracksDemo/TracksDemo_Prefix.pch;
 				INFOPLIST_FILE = TracksDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_PREFIX_HEADER = TracksDemo/TracksDemo_Prefix.pch;
 				INFOPLIST_FILE = TracksDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "0b8ba88f5fd70062887d55f87a970c59b1ceebcf",
-          "version": "8.39.0"
+          "revision": "0041fe6374a0557747d3c7f19888510a30684dfa",
+          "version": "9.1.0"
         }
       },
       {

--- a/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TracksDemo/TracksDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "0041fe6374a0557747d3c7f19888510a30684dfa",
-          "version": "9.1.0"
+          "revision": "f1eefffd88cd6dfe5751159a3b32ff3c8e5b3b32",
+          "version": "9.4.0"
         }
       },
       {


### PR DESCRIPTION
Fixes AINFRA-1677

This PR updates Tracks to use Sentry version 9.1 

Sentry SDK 9.1 has a minimum version of iOS 15 so this also force us to update Tracks library to be minimum iOS 15 and above.

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
