### PR TITLE
Release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ _None._
 
 ### Internal Changes
 
+_None._
+
+## 4.1.0
+
+### Internal Changes
+
 - The Sentry version used is now 9.4.0 [#315]
 
 ## 4.0.0


### PR DESCRIPTION
## Summary

Update changelog for 4.1.0 release.

### Internal Changes

- The Sentry version used is now 9.4.0 [#315]