### PR TITLE
Add compatibility for watchOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- watchOS compatibility [#317]
 
 ## 4.1.0
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/jedisct1/swift-sodium",
         "state": {
           "branch": null,
-          "revision": "4f9164a0a2c9a6a7ff53a2833d54a5c79c957342",
-          "version": "0.9.1"
+          "revision": "e7e799cd1eaa4d0f6d3eab56832e7f4b377f4a4f",
+          "version": "0.10.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
     dependencies: [
         // Runtime dependencies
         .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", from: "9.4.0"),
-        .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium", from: "0.9.1"),
+        .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium", from: "0.10.0"),
         .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.0.0"),
         // Tests dependencies
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.0.0"),

--- a/Sources/Event Logging/TracksService.m
+++ b/Sources/Event Logging/TracksService.m
@@ -10,7 +10,9 @@
 #endif
 
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_WATCH
+#import <WatchKit/WatchKit.h>
+#elif TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #else
 #import <AppKit/AppKit.h>
@@ -105,7 +107,11 @@ NSString *const USER_ID_ANON = @"anonId";
         [self resetTimer];
         
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_WATCH
+        NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
+        [defaultCenter addObserver:self selector:@selector(didEnterBackground:) name:WKApplicationDidEnterBackgroundNotification object:nil];
+        [defaultCenter addObserver:self selector:@selector(didBecomeActive:) name:WKApplicationDidBecomeActiveNotification object:nil];
+#elif TARGET_OS_IPHONE
         NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
         [defaultCenter addObserver:self selector:@selector(didEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
         [defaultCenter addObserver:self selector:@selector(didBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
@@ -374,7 +380,9 @@ NSString *const USER_ID_ANON = @"anonId";
 
 - (NSDictionary *)immutableDeviceProperties
 {
-#if TARGET_OS_IPHONE
+#if TARGET_OS_WATCH
+    CGSize screenSize = [[WKInterfaceDevice currentDevice] screenBounds].size;
+#elif TARGET_OS_IPHONE
     CGSize screenSize = [[UIScreen mainScreen] bounds].size;
 #else
     CGSize screenSize = [[NSScreen mainScreen] frame].size;

--- a/Sources/Experiments/ExPlat.swift
+++ b/Sources/Experiments/ExPlat.swift
@@ -1,5 +1,7 @@
 import Foundation
-#if os(iOS) || os(watchOS) || os(tvOS)
+#if os(watchOS)
+import WatchKit
+#elseif os(iOS) || os(tvOS)
 import UIKit
 #elseif os(macOS)
 import Cocoa
@@ -148,7 +150,9 @@ import Cocoa
     private func subscribeToNotifications() {
         let notificationCenter = NotificationCenter.default
 
-        #if os(iOS) || os(watchOS) || os(tvOS)
+        #if os(watchOS)
+        notificationCenter.addObserver(self, selector: #selector(applicationWillEnterForeground), name: WKApplication.willEnterForegroundNotification, object: nil)
+        #elseif os(iOS) || os(tvOS)
         notificationCenter.addObserver(self, selector: #selector(applicationWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
         #elseif os(macOS)
         notificationCenter.addObserver(self, selector: #selector(applicationWillEnterForeground), name: NSApplication.willBecomeActiveNotification, object: nil)
@@ -158,7 +162,9 @@ import Cocoa
     private func unsubscribeFromNotifications() {
         let notificationCenter = NotificationCenter.default
 
-        #if os(iOS) || os(watchOS) || os(tvOS)
+        #if os(watchOS)
+        notificationCenter.removeObserver(self, name: WKApplication.willEnterForegroundNotification, object: nil)
+        #elseif os(iOS) || os(tvOS)
         notificationCenter.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
         #elseif os(macOS)
         notificationCenter.removeObserver(self, name: NSApplication.willBecomeActiveNotification, object: nil)

--- a/Sources/Model/ObjC/Common/TracksDeviceInformation.m
+++ b/Sources/Model/ObjC/Common/TracksDeviceInformation.m
@@ -1,6 +1,8 @@
 #import "TracksDeviceInformation.h"
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_WATCH
+#import <WatchKit/WatchKit.h>
+#elif TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 @import UIDeviceIdentifier;
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
@@ -21,7 +23,7 @@
 @property (nonatomic, assign) BOOL isReachableByWiFi;
 @property (nonatomic, assign) BOOL isReachableByWWAN;
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
 @property (nonatomic, assign) UIDeviceOrientation lastKnownDeviceOrientation;
 @property (nonatomic, strong) NSString *lastKnownPreferredContentSizeCategory;
 #endif
@@ -42,7 +44,7 @@
 
 - (void)preloadDeviceProperties
 {
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
     void (^preload)(void) = ^(void) {
         self.lastKnownDeviceOrientation = UIDevice.currentDevice.orientation;
         self.lastKnownPreferredContentSizeCategory = UIApplication.sharedIfAvailable.preferredContentSizeCategory;
@@ -71,6 +73,8 @@
 {
 #if TARGET_OS_SIMULATOR
     return @"Carrier (Simulator)";
+#elif TARGET_OS_WATCH
+    return @"Not Applicable";
 #elif TARGET_OS_IPHONE
     CTTelephonyNetworkInfo *netInfo = [CTTelephonyNetworkInfo new];
     CTCarrier *carrier = [netInfo subscriberCellularProvider];
@@ -91,6 +95,8 @@
 {
 #if TARGET_OS_SIMULATOR
     return @"None (Simulator)";
+#elif TARGET_OS_WATCH
+    return @"Unknown";
 #elif TARGET_OS_IPHONE
     CTTelephonyNetworkInfo *netInfo = [CTTelephonyNetworkInfo new];
     NSString *type = nil;
@@ -112,7 +118,9 @@
 
 - (NSString *)model
 {
-#if TARGET_OS_IPHONE
+#if TARGET_OS_WATCH
+    return [[WKInterfaceDevice currentDevice] model];
+#elif TARGET_OS_IPHONE
     return [UIDeviceHardware platformString];
 #else   // Mac
     size_t size;
@@ -129,7 +137,9 @@
 
 - (NSString *)os
 {
-#if TARGET_OS_IPHONE
+#if TARGET_OS_WATCH
+    return @"watchOS";
+#elif TARGET_OS_IPHONE
     return [[UIDevice currentDevice] systemName];
 #else   // Mac
     return @"OS X";
@@ -138,7 +148,13 @@
 
 - (NSString *)version
 {
-#if TARGET_OS_IPHONE
+#if TARGET_OS_WATCH
+    NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
+    NSInteger major = version.majorVersion;
+    NSInteger minor = version.minorVersion;
+    NSInteger patch = version.patchVersion;
+    return [NSString stringWithFormat: @"%ld.%ld.%ld", (long)major, (long)minor, (long)patch];
+#elif TARGET_OS_IPHONE
     return [[UIDevice currentDevice] systemVersion];
 #else   // Mac
     NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
@@ -150,7 +166,9 @@
 }
 
 -(BOOL)isAppleWatchConnected{
-#if TARGET_OS_IPHONE
+#if TARGET_OS_WATCH
+    return YES;  // We're running on the watch itself
+#elif TARGET_OS_IPHONE
     return [[WatchSessionManager shared] hasBeenPreviouslyPaired];
 #else   // Mac
     return NO;
@@ -159,7 +177,9 @@
 
 -(BOOL)isVoiceOverEnabled{
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_WATCH
+    return WKAccessibilityIsVoiceOverRunning();
+#elif TARGET_OS_IPHONE
     return UIAccessibilityIsVoiceOverRunning();
 #else   // Mac
     Boolean exists = false;
@@ -174,7 +194,9 @@
 }
 
 -(NSString *)orientation{
-#if TARGET_OS_IPHONE
+#if TARGET_OS_WATCH
+    return @"Unknown";
+#elif TARGET_OS_IPHONE
      UIDeviceOrientation orientation = [self deviceOrientation];
 
      if (orientation == UIDeviceOrientationPortrait || orientation == UIDeviceOrientationPortraitUpsideDown) {
@@ -191,7 +213,7 @@
 
 #pragma mark - Calls that need to run on the main thread
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
 // This method was created because UIDevice.currentDevice.orientation should only
 // be called from the main thread.
 //
@@ -205,11 +227,13 @@
 #endif
 
 /// Preferred reading content size based on the accessibility setting of the iOS device.
-/// 
-/// - This will be NULL for Mac OS.
+///
+/// - This will be NULL for Mac OS and watchOS.
 ///
 - (NSString *)preferredContentSizeCategory {
-#if TARGET_OS_IPHONE
+#if TARGET_OS_WATCH
+    return NULL;
+#elif TARGET_OS_IPHONE
     if ([NSThread isMainThread]) {
         self.lastKnownPreferredContentSizeCategory = UIApplication.sharedIfAvailable.preferredContentSizeCategory;
     }
@@ -223,10 +247,12 @@
 /// Returns `true` if the preferred reading content size falls under accessibility category.
 ///
 /// - Uses `UIContentSizeCategoryIsAccessibilityCategory` method.
-/// - This will be `false` for Mac OS.
+/// - This will be `false` for Mac OS and watchOS.
 ///
 - (BOOL)isAccessibilityCategory {
-#if TARGET_OS_IPHONE
+#if TARGET_OS_WATCH
+    return NO;
+#elif TARGET_OS_IPHONE
     NSString *preferredCategory = [self preferredContentSizeCategory];
     if (preferredCategory == nil) {
         return NO;

--- a/Sources/Model/ObjC/Common/WatchSessionManager.m
+++ b/Sources/Model/ObjC/Common/WatchSessionManager.m
@@ -1,6 +1,6 @@
 #import "WatchSessionManager.h"
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
 #import <WatchConnectivity/WatchConnectivity.h>
 
 @interface WatchSessionManager()<WCSessionDelegate>
@@ -34,17 +34,17 @@
             return self;
         }
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
         if([WCSession isSupported]){
             self.session = [WCSession defaultSession];
-            
+
             if (self.session.activationState == WCSessionActivationStateActivated) {
                 [self setHasBeenPairedIfPossibleWithSession:self.session];
             } else {
                 self.session.delegate = self;
                 [self.session activateSession];
             }
-          
+
 
             self.hasBeenPaired = false;
         }
@@ -54,7 +54,7 @@
     return self;
 }
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
 - (void)setHasBeenPairedIfPossibleWithSession:(nonnull WCSession *)session {
     if(session.paired){
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"watch-has-been-previously-paired"];
@@ -69,7 +69,7 @@
 
 #pragma mark – WCSessionDelegate
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
 - (void)session:(nonnull WCSession *)session activationDidCompleteWithState:(WCSessionActivationState)activationState error:(nullable NSError *)error {
 
     [self setHasBeenPairedIfPossibleWithSession:session];

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -75,10 +75,12 @@ public class CrashLogging {
                 // input `SamplingContext` down the chain.
                 NSNumber(value: self.dataProvider.tracesSampler())
             }
+            #if !os(watchOS)
             options.configureProfiling = { [weak self] in
                 guard let self else { return }
                 $0.sessionSampleRate = Float(self.dataProvider.profilingRate)
             }
+            #endif
             options.enableNetworkTracking = self.dataProvider.enableNetworkTracking
             options.enableFileIOTracing = self.dataProvider.enableFileIOTracking
             options.enableCoreDataTracing = self.dataProvider.enableCoreDataTracking


### PR DESCRIPTION
Adds watchOS compatibility by fixing compilation errors and modifying various default values.

Primarily, I'd like to use the Sentry Crash Logging features to report errors from watchOS.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
