### PR TITLE
Replace test-collector-swift with JUnit upload

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,7 +22,13 @@ steps:
     command: |
       install_gems
       bundle exec fastlane ios test
-    plugins: *common_plugins
+    plugins:
+      - automattic/a8c-ci-toolkit#6.0.0
+      - test-collector#v1.11.0:
+          files: .build/report.junit
+          format: junit
+          missing-error: 0
+          api-token-env-name: BUILDKITE_ANALYTICS_TOKEN
     artifact_paths: ".build/logs/*.log"
 
   ######################
@@ -33,7 +39,13 @@ steps:
     command: |
       install_gems
       bundle exec fastlane mac test
-    plugins: *common_plugins
+    plugins:
+      - automattic/a8c-ci-toolkit#6.0.0
+      - test-collector#v1.11.0:
+          files: .build/report.junit
+          format: junit
+          missing-error: 0
+          api-token-env-name: BUILDKITE_ANALYTICS_TOKEN
     artifact_paths: ".build/logs/*.log"
 
   - label: ":swift: SwiftLint"

--- a/Package.resolved
+++ b/Package.resolved
@@ -38,15 +38,6 @@
         }
       },
       {
-        "package": "BuildkiteTestCollector",
-        "repositoryURL": "https://github.com/buildkite/test-collector-swift",
-        "state": {
-          "branch": null,
-          "revision": "77c7f492f5c1c9ca159f73d18f56bbd1186390b0",
-          "version": "0.3.0"
-        }
-      },
-      {
         "package": "UIDeviceIdentifier",
         "repositoryURL": "https://github.com/squarefrog/UIDeviceIdentifier",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,6 @@ let package = Package(
         // Tests dependencies
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.0.0"),
         .package(name: "OCMock", url: "https://github.com/erikdoe/ocmock", .branch("master")),
-        .package(name: "BuildkiteTestCollector", url: "https://github.com/buildkite/test-collector-swift", from: "0.3.0"),
     ],
     targets: [
         // ExPlat experiments
@@ -150,7 +149,6 @@ let package = Package(
                 "AutomatticTracks",
                 "AutomatticTracksEvents",
                 "AutomatticTracksModel",
-                "BuildkiteTestCollector",
                 .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
             ],
             path: "Tests",
@@ -162,7 +160,6 @@ let package = Package(
             name: "AutomatticTracksTestsObjC",
             dependencies: [
                 "AutomatticTracksEvents",
-                "BuildkiteTestCollector",
                 "OCMock",
             ],
             path: "Tests/Tests/ObjC"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,10 @@ platform :ios do
       deployment_target_version: '14.5',
       prelaunch_simulator: true,
       buildlog_path: BUILD_LOG_PATH,
-      derived_data_path: DERIVED_DATA_PATH
+      derived_data_path: DERIVED_DATA_PATH,
+      output_directory: BUILD_FOLDER,
+      result_bundle: true,
+      output_types: 'junit'
     )
   end
 end
@@ -29,7 +32,10 @@ platform :mac do
       scheme: 'TracksDemo Mac',
       project: PROJECT_PATH,
       buildlog_path: BUILD_LOG_PATH,
-      derived_data_path: DERIVED_DATA_PATH
+      derived_data_path: DERIVED_DATA_PATH,
+      output_directory: BUILD_FOLDER,
+      result_bundle: true,
+      output_types: 'junit'
     )
   end
 end


### PR DESCRIPTION
## Summary

Replaces the `test-collector-swift` SPM package (runtime XCTest hook) with the `test-collector` Buildkite plugin that uploads JUnit XML files to Test Engine.

The SPM package hooks into XCTest at runtime, so Swift Testing tests are invisible to Test Engine.
The Buildkite plugin uploads JUnit XML files post-step, which works with any test framework.

Fixes AINFRA-1977

## Testing
- Let CI run on this PR
- Verify all test steps pass
- Check the Buildkite Test Analytics dashboard to confirm results are received

---

*Posted by Claude (Opus 4.6) on behalf of @mokagio with approval.*