### PR TITLE
Fix logID setter silently failing when event.extra is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Fix `logID` setter silently failing when `event.extra` is nil, causing Sentry crash reports to intermittently miss the encrypted log UUID. [#320]
 
 ### Internal Changes
 

--- a/Sources/Remote Logging/EventLogging+Sentry.swift
+++ b/Sources/Remote Logging/EventLogging+Sentry.swift
@@ -70,7 +70,9 @@ extension Event {
             return self.extra?[Event.logIDKey] as? String
         }
         set {
-            self.extra?[Event.logIDKey] = newValue
+            var extras = self.extra ?? [:]
+            extras[Event.logIDKey] = newValue
+            self.extra = extras
         }
     }
 }

--- a/Tests/Tests/CrashLoggingTests.swift
+++ b/Tests/Tests/CrashLoggingTests.swift
@@ -202,6 +202,15 @@ class CrashLoggingTests: XCTestCase {
 
         XCTAssertNil(dataProvider.onCrashedLastRun)
     }
+
+    func testLogIDSetterInitializesExtraWhenNil() {
+        let event = Event(level: .fatal)
+        let uuid = UUID().uuidString
+        event.logID = uuid
+
+        XCTAssertEqual(event.extra?["logID"] as? String, uuid)
+        XCTAssertEqual(event.logID, uuid)
+    }
 }
 
 /// Allow throwing Strings as error


### PR DESCRIPTION
The logID setter used optional chaining (`self.extra?[key] = newValue`), which is a no-op when `extra` is nil. This caused Sentry crash reports to intermittently miss the encrypted log UUID. Now the setter initializes `extra` with an empty dictionary when nil before assigning the value.

---

- [X] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
