### PR TITLE
Release 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ _None._
 
 ### Bug Fixes
 
+_None._
+
+### Internal Changes
+
+_None._
+
+## 4.2.0
+
+### Bug Fixes
+
 - Fix `logID` setter silently failing when `event.extra` is nil, causing Sentry crash reports to intermittently miss the encrypted log UUID. [#320]
 
 ### Internal Changes


### PR DESCRIPTION
## Changes in 4.2.0

### Bug Fixes

- Fix `logID` setter silently failing when `event.extra` is nil, causing Sentry crash reports to intermittently miss the encrypted log UUID. [#320]

### Internal Changes

- watchOS compatibility [#317]