### PR TITLE
Fix UIApplication non-public API usage on watchOS

### DIFF
--- a/Sources/Model/ObjC/Common/UIApplication+Extensions.h
+++ b/Sources/Model/ObjC/Common/UIApplication+Extensions.h
@@ -1,7 +1,7 @@
 @import Foundation;
 
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
 @import UIKit;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Model/ObjC/Common/UIApplication+Extensions.m
+++ b/Sources/Model/ObjC/Common/UIApplication+Extensions.m
@@ -2,7 +2,7 @@
 #import "UIApplication+Extensions.h"
 
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
 @implementation UIApplication (SharedIfAvailable)
 
 + (UIApplication *)sharedIfAvailable {


### PR DESCRIPTION
## Summary

- `TARGET_OS_IPHONE` evaluates to `1` on watchOS, causing the `UIApplication` category in `UIApplication+Extensions.{h,m}` to be compiled into Watch binaries
- `UIApplication` is a non-public class on watchOS, triggering App Store rejection error 90338
- Added `&& !TARGET_OS_WATCH` to the preprocessor guards, matching the pattern already used elsewhere in the library (e.g. `TracksDeviceInformation.m`, `ApplicationFacade.swift`, `ExPlat.swift`)

## Test plan

- [ ] Build the library targeting watchOS and confirm no `UIApplication` symbols are included
- [ ] Verify iOS builds are unaffected
- [ ] Submit a Watch app using this library to App Store Connect and confirm error 90338 no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)