### PR TITLE
Avoid definition of sharedIsAvailable for WatchOS builds

### DIFF
--- a/Sources/Model/ObjC/Common/UIApplication+Extensions.h
+++ b/Sources/Model/ObjC/Common/UIApplication+Extensions.h
@@ -1,7 +1,7 @@
 @import Foundation;
 
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE  && !TARGET_OS_WATCH
 @import UIKit;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Model/ObjC/Common/UIApplication+Extensions.m
+++ b/Sources/Model/ObjC/Common/UIApplication+Extensions.m
@@ -2,7 +2,7 @@
 #import "UIApplication+Extensions.h"
 
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE  && !TARGET_OS_WATCH
 @implementation UIApplication (SharedIfAvailable)
 
 + (UIApplication *)sharedIfAvailable {


### PR DESCRIPTION
---
This PR updates the definition of the `sharedIsAvailable` method to not be compile for WatchOS targets to it avoid issues when deploying AppStore builds. 

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
