### PR TITLE
Release 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 4.2.1
+
+### Bug Fixes
+
+- Fix `UIApplication` non-public API usage on watchOS causing App Store rejection (error 90338). [#323]
+
 ## 4.2.0
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

- Add missing changelog entry for #323
- Release 4.2.1

### Bug Fixes

- Fix `UIApplication` non-public API usage on watchOS causing App Store rejection (error 90338). [#323]

---

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*