### PR TITLE
Enable SwiftLint rule: empty_count

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,6 +26,9 @@ only_rules:
   # Imports should be unique.
   - duplicate_imports
 
+  # Prefer checking `isEmpty` over comparing `count` to zero.
+  - empty_count
+
   # Arguments can be omitted when matching enums with associated types if they
   # are not used.
   - empty_enum_arguments

--- a/Tests/Tests/Event Logging/LogEncryptionTests.swift
+++ b/Tests/Tests/Event Logging/LogEncryptionTests.swift
@@ -57,7 +57,7 @@ class LogEncryptionTests: XCTestCase {
         XCTAssertNotNil(UUID(uuidString: encryptedMessage.uuid), "The UUID must be valid")
         XCTAssertEqual(encryptedMessage.header.count, 32, "The header should be 32 bytes long")
         XCTAssertEqual(encryptedMessage.encryptedKey.count, 108, "The encrypted key should be 108 bytes long")
-        XCTAssert(!encryptedMessage.messages.isEmpty, "There should be at least one message")
+        XCTAssertFalse(encryptedMessage.messages.isEmpty, "There should be at least one message")
     }
 }
 

--- a/Tests/Tests/Event Logging/LogEncryptionTests.swift
+++ b/Tests/Tests/Event Logging/LogEncryptionTests.swift
@@ -57,7 +57,7 @@ class LogEncryptionTests: XCTestCase {
         XCTAssertNotNil(UUID(uuidString: encryptedMessage.uuid), "The UUID must be valid")
         XCTAssertEqual(encryptedMessage.header.count, 32, "The header should be 32 bytes long")
         XCTAssertEqual(encryptedMessage.encryptedKey.count, 108, "The encrypted key should be 108 bytes long")
-        XCTAssert(encryptedMessage.messages.count > 0, "There should be at least one message")
+        XCTAssert(!encryptedMessage.messages.isEmpty, "There should be at least one message")
     }
 }
 


### PR DESCRIPTION
## Summary

- Enables the `empty_count` SwiftLint rule, which prefers checking `isEmpty` over comparing `count` to zero.
- ~~Zero violations found — the codebase already conforms. No source changes needed.~~ Update: After a rebase, a violation was discovered (this branch has been open for a wile due to it failing CI because of the issue addressed by #328)
- Auto-fixed violations: 0
- Manual fixes: 0

This is part of the Orchard SwiftLint rollout campaign.

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*