### PR TITLE
Add BuildTools for SwiftLint version pinning

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-swiftlint_version: 0.58.2
+swiftlint_version: 0.63.2
 
 excluded:
   - .build
@@ -47,8 +47,8 @@ only_rules:
 
 # Rules configuration
 
-control_statement: 
-  severity: error 
+control_statement:
+  severity: error
 
 custom_rules:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,10 +67,13 @@ The default (`clean:false`) skips SPM resolution for faster incremental builds.
 ### Lint
 
 ```
-swiftlint
+make lint
 ```
 
-Autofix available via `swiftlint lint --fix`.
+Autofix available via `make format`.
+
+SwiftLint runs via the `BuildTools/` SPM plugin, which reads the version from `.swiftlint.yml`.
+Do not use the global `swiftlint` binary — it may be a different version.
 
 ## Conventions
 

--- a/BuildTools/Empty.swift
+++ b/BuildTools/Empty.swift
@@ -1,0 +1,2 @@
+// This file intentionally left empty.
+// BuildTools is a helper package for SwiftLint plugin resolution.

--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "c6737edfd7078ad723024c817b128ee40ff5b15528bfa853fed61579c49e4882",
+  "pins" : [
+    {
+      "identity" : "swiftlintplugins",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
+      "state" : {
+        "revision" : "7a3d77f3dd9f91d5cea138e52c20cfceabf352de",
+        "version" : "0.58.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "7a3d77f3dd9f91d5cea138e52c20cfceabf352de",
-        "version" : "0.58.2"
+        "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
+        "version" : "0.63.2"
       }
     }
   ],

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:6.0
+import Foundation
+import PackageDescription
+
+let package = Package(
+    name: "BuildTools",
+    platforms: [.macOS(.v10_13)],
+    dependencies: [
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", exact: loadSwiftLintVersion()),
+    ],
+    targets: [.target(name: "BuildTools", path: "")]
+)
+
+func loadSwiftLintVersion() -> Version {
+    let swiftLintConfigURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .appendingPathComponent("..")
+        .appendingPathComponent(".swiftlint.yml")
+
+    guard let yamlString = try? String(contentsOf: swiftLintConfigURL) else {
+        fatalError("Failed to read SwiftLint config file at \(swiftLintConfigURL).")
+    }
+
+    guard let versionLine = yamlString.components(separatedBy: .newlines)
+        .first(where: { $0.contains("swiftlint_version") }) else {
+        fatalError("SwiftLint version not found in YAML file.")
+    }
+
+    // Assumes the format `swiftlint_version: <version>`
+    guard let version = Version(versionLine.components(separatedBy: ":")
+        .last?
+        .trimmingCharacters(in: .whitespaces) ?? "") else {
+        fatalError("Failed to extract SwiftLint version.")
+    }
+
+    return version
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+SWIFTLINT_CMD = swiftlint --working-directory .. --quiet
+
+define run_in_buildtools
+	@export SDKROOT=$$(xcrun --sdk macosx --show-sdk-path) && \
+	env -C BuildTools swift package plugin \
+		--allow-writing-to-directory .. \
+		--allow-writing-to-package-directory \
+		$(1)
+endef
+
+.PHONY: lint format
+
+lint: ## Lint the codebase
+	$(call run_in_buildtools,$(SWIFTLINT_CMD))
+
+format: ## Lint and autocorrect linter errors
+	$(call run_in_buildtools,$(SWIFTLINT_CMD) --fix)


### PR DESCRIPTION
## Summary

- Adds `BuildTools/Package.swift` with the SwiftLint SPM plugin, reading the version from `.swiftlint.yml`
- Adds a `Makefile` with `make lint` and `make format` targets
- Updates `AGENTS.md` to document the new lint commands

This matches the pattern used by WordPress-iOS, WooCommerce-iOS, Pocket Casts, and Simplenote.
Ensures local and CI SwiftLint runs use the same pinned version (updated to 0.63.2).

<img width="2730" height="872" alt="image" src="https://github.com/user-attachments/assets/6d946ef2-8471-49d6-9ed4-60916f22991f" />


## Test plan

- [x] `make lint` runs cleanly (0 violations)
- [x] `make format` runs cleanly
- [x] CI passes with the new setup

Part of the [Orchard](https://github.com/nicorivas/orchard) SwiftLint rollout campaign.

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*