### PR TITLE
Address flaky event logging tests

### DIFF
--- a/Sources/Encrypted Logs/EventLogging.swift
+++ b/Sources/Encrypted Logs/EventLogging.swift
@@ -21,6 +21,7 @@ public class EventLogging {
     /// Coordinates one-at-a-time file log dequeuing and upload
     private let lock = NSLock()
     private let processingQueue = DispatchQueue(label: "event-logging-upload")
+    private var uploadsPausedByDelegate = false
 
     /// Uploads Events
     private let uploadManager: EventLoggingUploadManager
@@ -98,10 +99,19 @@ extension EventLogging {
             return
         }
 
+        if uploadsPausedByDelegate {
+            guard delegate.shouldUploadLogFiles else {
+                lock.unlock()
+                return
+            }
+
+            uploadsPausedByDelegate = false
+        }
+
         /// If the delegate is reporting that we shouldn't upload log files, pause upload to prevent an endless loop
         guard delegate.shouldUploadLogFiles else {
+            uploadsPausedByDelegate = true
             delegate.uploadCancelledByDelegate(log)
-            retryUploadsAt(.distantFuture)
             lock.unlock()
             return
         }

--- a/Sources/Encrypted Logs/EventLogging.swift
+++ b/Sources/Encrypted Logs/EventLogging.swift
@@ -100,11 +100,15 @@ extension EventLogging {
         }
 
         if uploadsPausedByDelegate {
+            // Delegate cancellation is a policy pause rather than a backoff retry:
+            // stay idle until uploads are explicitly allowed again
             guard delegate.shouldUploadLogFiles else {
                 lock.unlock()
                 return
             }
 
+            // Clear the pause state once the delegate allows uploads again so queued
+            // logs can resume on this run
             uploadsPausedByDelegate = false
         }
 

--- a/Tests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
+++ b/Tests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
@@ -16,7 +16,15 @@ class EventLoggingUploadManagerTests: XCTestCase {
         let uploadManager = self.uploadManager(delegate: delegate)
 
         waitForExpectation(timeout: 1.0) { exp in
-            uploadManager.upload(LogFile.containingRandomString(), then: { _ in exp.fulfill() })
+            exp.expectedFulfillmentCount = 2
+
+            delegate.withDidFinishUploadingCallback { _ in
+                exp.fulfill()
+            }
+
+            uploadManager.upload(LogFile.containingRandomString(), then: { _ in
+                exp.fulfill()
+            })
         }
 
         XCTAssertTrue(delegate.didStartUploadingTriggered)

--- a/Tests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
+++ b/Tests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
@@ -16,6 +16,8 @@ class EventLoggingUploadManagerTests: XCTestCase {
         let uploadManager = self.uploadManager(delegate: delegate)
 
         waitForExpectation(timeout: 1.0) { exp in
+            // The upload callback fires before `didFinishUploadingLog`, so wait for both
+            // to avoid asserting on delegate state before the upload fully settles
             exp.expectedFulfillmentCount = 2
 
             delegate.withDidFinishUploadingCallback { _ in


### PR DESCRIPTION
Recently, I noticed the Mac tests being flaky in CI. I got Codex to look into it and this seems like a decent way to address the issue.

## Summary
- stop rescheduling repeated delegate-cancelled uploads so they do not leak callbacks into later tests
- wait for `didFinishUploadingLog` in the upload manager success test before asserting completion
- keep the change scoped to the event logging flaky-test fix identified from recent Buildkite failures

## Testing

Created #329 with `100` parallel test builds. All green

<img width="509" height="313" alt="image" src="https://github.com/user-attachments/assets/e609ad1e-f479-49cd-942e-6ad16d110a80" />
