### PR TITLE
Enable SwiftLint rule: empty_string

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -27,6 +27,9 @@ only_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
+  # Empty strings should be compared to `""` only if `isEmpty` cannot be used.
+  - empty_string
+
   # MARK comment should be in valid format.
   - mark
 


### PR DESCRIPTION
Enable SwiftLint rule `empty_string` to prefer `isEmpty` over explicit empty-string comparisons where applicable.

- Number of auto-fixed violations: 0
- Number of agentic fixes (manual): 0
- Violations left for human review: 0
- Part of the Orchard SwiftLint rollout campaign