### PR TITLE
Enable SwiftLint rule: contains_over_filter_is_empty

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,6 +17,9 @@ only_rules:
   # There should be no space before and one after any comma.
   - comma
 
+  # Prefer `contains` over using `filter(where:).isEmpty`.
+  - contains_over_filter_is_empty
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 


### PR DESCRIPTION
## Summary

- Enable the `contains_over_filter_is_empty` SwiftLint rule, which prefers `contains` over `filter(where:).isEmpty`.
- No violations found in the codebase — this is a config-only change.
- Part of the Orchard SwiftLint rollout campaign.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.

No changelog entry needed — linter config only.

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*