### PR TITLE
Update addressable to 2.9.0 (CVE-2026-35611)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,8 +5,8 @@ GEM
       base64
       nkf
       rexml
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
     ast (2.4.2)
     atomos (0.1.3)
@@ -170,7 +170,7 @@ GEM
       ast (~> 2.4.1)
       racc
     plist (3.7.1)
-    public_suffix (4.0.7)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)


### PR DESCRIPTION
Fixes AINFRA-2264

## Summary
- Bumps `addressable` gem from vulnerable version to 2.9.0
- Fixes CVE-2026-35611 (GHSA-h27x-rffw-24p4) — high severity ReDoS in Addressable templates
- Vulnerable range: `>= 2.3.0, < 2.9.0`

## Test plan
- [ ] CI passes
- [ ] No changes to app behavior (transitive dependency only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)