### PR TITLE
Enable SwiftLint rule: duplicate_imports

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -23,6 +23,9 @@ only_rules:
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 
+  # Imports should be unique.
+  - duplicate_imports
+
   # Arguments can be omitted when matching enums with associated types if they
   # are not used.
   - empty_enum_arguments


### PR DESCRIPTION
## What

Enables the SwiftLint [`duplicate_imports`](https://realm.github.io/SwiftLint/duplicate_imports.html) rule, which flags the same module being imported more than once in the same file.

## Details

- Auto-fixed violations: 0
- Manual (agentic) fixes: 0
- Violations left for human review: 0

The codebase was already clean for this rule — the only change is adding `duplicate_imports` to `only_rules` in `.swiftlint.yml` (alphabetically placed).

## Context

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint), progressively enabling SwiftLint rules across Automattic's iOS repositories one rule at a time.