### PR TITLE
Enable SwiftLint rule: joined_default_parameter

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -36,6 +36,10 @@ only_rules:
   # Empty strings should be compared to `""` only if `isEmpty` cannot be used.
   - empty_string
 
+  # When calling the `joined` method on an array of strings, omit an
+  # explicit empty-string separator since that is the default.
+  - joined_default_parameter
+
   # MARK comment should be in valid format.
   - mark
 


### PR DESCRIPTION
## What

Enables the SwiftLint [`joined_default_parameter`](https://realm.github.io/SwiftLint/joined_default_parameter.html) rule, which flags calls to `joined(separator:)` that pass the default empty-string separator and should just use `joined()`.

## Details

- Auto-fixed violations: 0
- Manual (agentic) fixes: 0
- Violations left for human review: 0

The codebase was already clean for this rule — the two `joined(separator:)` call sites both pass non-default separators. The only change is adding `joined_default_parameter` to `only_rules` in `.swiftlint.yml` (alphabetically placed).

## Context

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint), progressively enabling SwiftLint rules across Automattic's iOS repositories one rule at a time.