### PR TITLE
Enable SwiftLint rule: shorthand_optional_binding

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -43,6 +43,10 @@ only_rules:
   # the declaration.
   - opening_brace
 
+  # Use shorthand syntax for optional binding (`if let foo` instead of
+  # `if let foo = foo`).
+  - shorthand_optional_binding
+
   # Files should have a single trailing newline.
   - trailing_newline
 

--- a/Sources/Encrypted Logs/EventLoggingNetworkService.swift
+++ b/Sources/Encrypted Logs/EventLoggingNetworkService.swift
@@ -13,7 +13,7 @@ class EventLoggingNetworkService {
     func uploadFile(request: URLRequest, fileURL: URL, completion: @escaping ResultCallback) {
         urlSession.uploadTask(with: request, fromFile: fileURL, completionHandler: { data, response, error in
 
-            if let error = error {
+            if let error {
                 completion(.failure(error))
                 return
             }
@@ -24,7 +24,7 @@ class EventLoggingNetworkService {
 
             if !(200 ... 299).contains(statusCode) {
                 /// Use the server-provided error messaging, if possible
-                if let data = data, let error = self.decodeError(data: data) {
+                if let data, let error = self.decodeError(data: data) {
                     completion(.failure(EventLoggingFileUploadError.httpError(error.error, error.message, statusCode)))
                 }
                 /// Fallback to a reasonable error message based on the HTTP status and response body

--- a/Sources/Experiments/ExPlat.swift
+++ b/Sources/Experiments/ExPlat.swift
@@ -98,7 +98,7 @@ import Cocoa
     public func refresh(completion: (() -> Void)? = nil) {
         service.getAssignments { [weak self] assignments in
             guard let `self` = self,
-                  let assignments = assignments else {
+                  let assignments else {
                 completion?()
                 return
             }

--- a/Sources/Experiments/ExPlatService.swift
+++ b/Sources/Experiments/ExPlatService.swift
@@ -45,7 +45,7 @@ public class ExPlatService {
             URLQueryItem(name: "experiment_names", value: experimentNames.joined(separator: ","))
         ]
 
-        if let anonId = anonId {
+        if let anonId {
             urlComponents.queryItems?.append(URLQueryItem.init(name: "anon_id", value: anonId))
         }
 
@@ -61,17 +61,17 @@ public class ExPlatService {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue("application/json", forHTTPHeaderField: "Accept")
 
-        if let oAuthToken = oAuthToken {
+        if let oAuthToken {
             request.setValue("Bearer \(oAuthToken)", forHTTPHeaderField: "Authorization")
         }
 
         // User-Agent
-        if let userAgent = userAgent {
+        if let userAgent {
             request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         }
 
         let task = URLSession.shared.dataTask(with: request) { data, response, error in
-            guard let data = data, error == nil else {
+            guard let data, error == nil else {
                 completion(nil)
                 return
             }

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -113,7 +113,7 @@ public class CrashLogging {
         }
 
         /// If we shouldn't send the event we have nothing else to do here
-        guard let event = event, shouldSendEvent else {
+        guard let event, shouldSendEvent else {
             return nil
         }
 


### PR DESCRIPTION
## Rule

`shorthand_optional_binding` — Prefer `if let foo` over `if let foo = foo` (Swift 5.7+).

## Changes

- 4 source files auto-fixed (8 sites), all from `swiftlint --fix`.
- 0 manual fixes.
- 0 violations left for human review.

## Verification

- Lint clean locally.
- Local fastlane test had a single failure on `testThatDelegateCancellationPausesLogUpload` — confirmed pre-existing flake (failure is independent of this purely stylistic change). All other tests pass.