### PR TITLE
Enable SwiftLint rule: unused_closure_parameter

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -60,6 +60,9 @@ only_rules:
   # Lines should not have trailing whitespace.
   - trailing_whitespace
 
+  # Unused parameters in closures should be replaced with `_`.
+  - unused_closure_parameter
+
   - custom_rules
 
 # Rules configuration

--- a/Sources/Experiments/ExPlatService.swift
+++ b/Sources/Experiments/ExPlatService.swift
@@ -70,7 +70,7 @@ public class ExPlatService {
             request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         }
 
-        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+        let task = URLSession.shared.dataTask(with: request) { data, _, error in
             guard let data, error == nil else {
                 completion(nil)
                 return

--- a/Tests/Tests/Event Logging/EventLoggingTests.swift
+++ b/Tests/Tests/Event Logging/EventLoggingTests.swift
@@ -23,11 +23,11 @@ class EventLoggingTests: XCTestCase {
             exp.expectedFulfillmentCount = uploadCount
 
             let eventLogging = self.eventLogging(delegate: MockEventLoggingDelegate()
-                    .withDidStartUploadingCallback { log in
+                    .withDidStartUploadingCallback { _ in
                         XCTAssertFalse(isUploading, "Only one upload should be running at the same time")
                         isUploading = true
                     }
-                    .withDidFinishUploadingCallback { log in
+                    .withDidFinishUploadingCallback { _ in
                         XCTAssertTrue(isUploading, "Only one upload should be running at the same time")
                         isUploading = false
                         exp.fulfill()

--- a/Tests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
+++ b/Tests/Tests/Event Logging/EventLoggingUploadManagerTests.swift
@@ -61,7 +61,7 @@ class EventLoggingUploadManagerTests: XCTestCase {
 
             let delegate = MockEventLoggingDelegate()
                 .withShouldUploadLogFilesValue(false)
-                .withUploadCancelledCallback { logFile in
+                .withUploadCancelledCallback { _ in
                     exp.fulfill()
                 }
 
@@ -87,7 +87,7 @@ class EventLoggingUploadManagerTests: XCTestCase {
             exp.expectedFulfillmentCount = 2
 
             let delegate = MockEventLoggingDelegate()
-                .withUploadFailedCallback { error, _ in
+                .withUploadFailedCallback { _, _ in
                     exp.fulfill()
                 }
 

--- a/Tests/Tests/TracksEventPersistenceServiceTests.swift
+++ b/Tests/Tests/TracksEventPersistenceServiceTests.swift
@@ -81,7 +81,7 @@ class TracksEventPersistenceServiceTests: XCTestCase {
         let context = contextManager.managedObjectContext
         let service = TracksEventPersistenceService(managedObjectContext: context)
 
-        let uuids = (0 ..< 2002).map { index in
+        let uuids = (0 ..< 2002).map { _ in
             UUID()
         }
 
@@ -164,7 +164,7 @@ class TracksEventPersistenceServiceTests: XCTestCase {
         let context = contextManager.managedObjectContext
         let service = TracksEventPersistenceService(managedObjectContext: context)
 
-        let uuids = (0 ..< 2002).map { index in
+        let uuids = (0 ..< 2002).map { _ in
             UUID()
         }
 


### PR DESCRIPTION
### What

Enable the [`unused_closure_parameter`](https://realm.github.io/SwiftLint/unused_closure_parameter.html) SwiftLint rule.

The rule flags closure parameters that are declared but never used, suggesting they be replaced with `_`.

### Counts

- Auto-fixed: 7
- Manual: 0
- Left for review: 0

### Notes

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).