### PR TITLE
Enable SwiftLint rule: `unneeded_parentheses_in_closure_argument`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -63,6 +63,9 @@ only_rules:
   # Lines should not have trailing whitespace.
   - trailing_whitespace
 
+  # Closure arguments should not be wrapped in parentheses.
+  - unneeded_parentheses_in_closure_argument
+
   - custom_rules
 
 # Rules configuration

--- a/Sources/Encrypted Logs/LogEncryptor.swift
+++ b/Sources/Encrypted Logs/LogEncryptor.swift
@@ -52,7 +52,7 @@ class LogEncryptor {
         """.data(using: .utf8)!)
 
         /// Use the `next:` label because of https://bugs.swift.org/browse/SR-1582
-        try inputFileHandle.readChunkedDataToEndOfFile(next: { (data) in
+        try inputFileHandle.readChunkedDataToEndOfFile(next: { data in
             guard let message = stream_enc.push(message: Bytes(data)) else {           // encrypt the data
                 throw LogEncryptorError.unableToEncryptFile
             }

--- a/Tests/Tests/Event Logging/EventLoggingTests.swift
+++ b/Tests/Tests/Event Logging/EventLoggingTests.swift
@@ -19,7 +19,7 @@ class EventLoggingTests: XCTestCase {
         let uploadCount = Int.random(in: 3...10)
         var isUploading = false
 
-        waitForExpectation() { (exp) in
+        waitForExpectation() { exp in
             exp.expectedFulfillmentCount = uploadCount
 
             let eventLogging = self.eventLogging(delegate: MockEventLoggingDelegate()
@@ -47,7 +47,7 @@ class EventLoggingTests: XCTestCase {
         let uploadCount = Int.random(in: 3...10)
         let logs = (0...uploadCount).map { _ in LogFile.containingRandomString() }
 
-        try waitForExpectation() { (exp) in
+        try waitForExpectation() { exp in
             exp.expectedFulfillmentCount = logs.count
 
             let delegate = MockEventLoggingDelegate()
@@ -70,7 +70,7 @@ class EventLoggingTests: XCTestCase {
 
         let uploadCount = Int.random(in: 3...10)
 
-        waitForExpectation() { (exp) in
+        waitForExpectation() { exp in
             exp.expectedFulfillmentCount = 1
             exp.assertForOverFulfill = true
 


### PR DESCRIPTION
### What

Enable the [`unneeded_parentheses_in_closure_argument`](https://realm.github.io/SwiftLint/unneeded_parentheses_in_closure_argument.html) SwiftLint rule.

The rule flags closure declarations whose argument list is wrapped in unnecessary parentheses (e.g. `{ (x) in ... }`), preferring `{ x in ... }`.

### Counts

- Auto-fixed: 4
- Manual: 0
- Left for review: 0

### Notes

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).