### PR TITLE
Enable SwiftLint rule: contains_over_filter_count

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,6 +17,9 @@ only_rules:
   # There should be no space before and one after any comma.
   - comma
 
+  # Prefer `contains` over `filter(where:).count`.
+  - contains_over_filter_count
+
   # Prefer `contains` over using `filter(where:).isEmpty`.
   - contains_over_filter_is_empty
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`contains_over_filter_count`](https://realm.github.io/SwiftLint/contains_over_filter_count.html) rule.

The rule prefers `xs.contains { ... }` over `xs.filter { ... }.count > 0` (and the `== 0` / `!= 0` variants), which is a performance and clarity win.

- **0 violations** in the current codebase, so no code changes — only the rule entry in `.swiftlint.yml`.
- The rule will catch new occurrences in future code.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
