### PR TITLE
Enable SwiftLint rule: contains_over_first_not_nil

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,6 +20,9 @@ only_rules:
   # Prefer `contains` over using `filter(where:).isEmpty`.
   - contains_over_filter_is_empty
 
+  # Prefer `contains` over `first(where:) != nil`.
+  - contains_over_first_not_nil
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`contains_over_first_not_nil`](https://realm.github.io/SwiftLint/contains_over_first_not_nil.html) rule.

The rule prefers `xs.contains { ... }` over `xs.first(where: { ... }) != nil` (and the `firstIndex` variant), which is a performance and clarity win.

- **0 violations** in the current codebase, so no code changes — only the rule entry in `.swiftlint.yml`.
- The rule will catch new occurrences in future code.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
