### PR TITLE
Enable SwiftLint rule: contains_over_range_nil_comparison

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,6 +20,9 @@ only_rules:
   # Prefer `contains` over using `filter(where:).isEmpty`.
   - contains_over_filter_is_empty
 
+  # Prefer `contains` over `range(of:) != nil` and `range(of:) == nil`.
+  - contains_over_range_nil_comparison
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`contains_over_range_nil_comparison`](https://realm.github.io/SwiftLint/contains_over_range_nil_comparison.html) rule.

The rule prefers `s.contains(...)` over `s.range(of:) != nil` (and `== nil`), which is a clarity win.

- See commit message for the violation count and any rewrites.
- The change is type-preserving (Bool→Bool) — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
