### PR TITLE
Enable SwiftLint rule: sorted_first_last

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -54,6 +54,9 @@ only_rules:
   # `if let foo = foo`).
   - shorthand_optional_binding
 
+  # Prefer `min(by:)` / `max(by:)` over `sorted { ... }.first` / `.last`.
+  - sorted_first_last
+
   # Files should have a single trailing newline.
   - trailing_newline
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`sorted_first_last`](https://realm.github.io/SwiftLint/sorted_first_last.html) rule.

The rule prefers `min(by:)` / `max(by:)` over `sorted { ... }.first` / `.last`. This avoids materialising the entire sorted array when only one element is needed.

- See commit message for the violation count and any rewrites.
- The change is type-preserving (`Element?`→`Element?`) — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
