### PR TITLE
Enable SwiftLint rule: reduce_into

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -50,6 +50,9 @@ only_rules:
   # over `CGPoint(x: 0, y: 0)`).
   - prefer_zero_over_explicit_init
 
+  # Prefer `reduce(into:_:)` over `reduce(_:_:)` for non-trivial accumulator types.
+  - reduce_into
+
   # Use shorthand syntax for optional binding (`if let foo` instead of
   # `if let foo = foo`).
   - shorthand_optional_binding


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`reduce_into`](https://realm.github.io/SwiftLint/reduce_into.html) rule.

The rule prefers `reduce(into:_:)` over `reduce(_:_:)` for copy-on-write accumulator types (arrays, dictionaries, sets, strings). `reduce(into:)` mutates the accumulator in place and avoids the per-iteration copy cost.

- See commit message for the violation count and any rewrites.
- The change is type-preserving — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
