### PR TITLE
Enable SwiftLint rule: array_init

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -11,6 +11,9 @@ excluded:
   - vendor
 
 only_rules:
+  # Prefer `Array(xs)` over `xs.map { $0 }`.
+  - array_init
+
   # Colons should be next to the identifier when specifying a type.
   - colon
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`array_init`](https://realm.github.io/SwiftLint/array_init.html) rule.

The rule prefers `Array(xs)` over the `xs.map { $0 }` identity transform when converting a sequence into an Array.

- See commit message for the violation count and any rewrites.
- The change is type-preserving — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
