### PR TITLE
Enable SwiftLint rule: redundant_type_annotation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -50,6 +50,9 @@ only_rules:
   # over `CGPoint(x: 0, y: 0)`).
   - prefer_zero_over_explicit_init
 
+  # Type annotations are redundant when the type can be inferred.
+  - redundant_type_annotation
+
   # Use shorthand syntax for optional binding (`if let foo` instead of
   # `if let foo = foo`).
   - shorthand_optional_binding

--- a/Sources/Encrypted Logs/ExponentialBackoffTimer.swift
+++ b/Sources/Encrypted Logs/ExponentialBackoffTimer.swift
@@ -56,5 +56,5 @@ struct ExponentialBackoffTimer {
     private(set) internal var next: DispatchTime = .now()
 
     /// A `Date` representation of `next`.
-    private(set) var nextDate: Date = Date()
+    private(set) var nextDate = Date()
 }


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`redundant_type_annotation`](https://realm.github.io/SwiftLint/redundant_type_annotation.html) rule.

The rule flags `let foo: Int = 5` where the type annotation is implied by the literal/expression on the right.

- Auto-fixed by `swiftlint --fix`.
- The change is type-preserving — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
