### PR TITLE
Enable SwiftLint zero-violation rules (10 rules)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -74,6 +74,9 @@ only_rules:
   # Prefer `reduce(into:_:)` over `reduce(_:_:)` for non-trivial accumulator types.
   - reduce_into
 
+  # `nil` coalescing on a non-optional is redundant.
+  - redundant_nil_coalescing
+
   # Use shorthand syntax for optional binding (`if let foo` instead of
   # `if let foo = foo`).
   - shorthand_optional_binding

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -51,6 +51,9 @@ only_rules:
   # Prefer `first(where:)` over `filter { }.first`.
   - first_where
 
+  # Prefer `last(where:)` over `filter { }.last`.
+  - last_where
+
   # MARK comment should be in valid format.
   - mark
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -11,6 +11,9 @@ excluded:
   - vendor
 
 only_rules:
+  # Prefer `Array(xs)` over `xs.map { $0 }`.
+  - array_init
+
   # Colons should be next to the identifier when specifying a type.
   - colon
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -65,6 +65,9 @@ only_rules:
   # over `CGPoint(x: 0, y: 0)`).
   - prefer_zero_over_explicit_init
 
+  # Prefer `reduce(into:_:)` over `reduce(_:_:)` for non-trivial accumulator types.
+  - reduce_into
+
   # Use shorthand syntax for optional binding (`if let foo` instead of
   # `if let foo = foo`).
   - shorthand_optional_binding

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -51,6 +51,9 @@ only_rules:
   # Prefer `first(where:)` over `filter { }.first`.
   - first_where
 
+  # Prefer `flatMap { ... }` over `map { ... }.reduce([], +)`.
+  - flatmap_over_map_reduce
+
   # Prefer `last(where:)` over `filter { }.last`.
   - last_where
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,6 +17,9 @@ only_rules:
   # There should be no space before and one after any comma.
   - comma
 
+  # Prefer `contains` over `filter(where:).count`.
+  - contains_over_filter_count
+
   # Prefer `contains` over using `filter(where:).isEmpty`.
   - contains_over_filter_is_empty
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -23,6 +23,9 @@ only_rules:
   # Prefer `contains` over using `filter(where:).isEmpty`.
   - contains_over_filter_is_empty
 
+  # Prefer `contains` over `first(where:) != nil`.
+  - contains_over_first_not_nil
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -48,6 +48,9 @@ only_rules:
   # Empty strings should be compared to `""` only if `isEmpty` cannot be used.
   - empty_string
 
+  # Prefer `first(where:)` over `filter { }.first`.
+  - first_where
+
   # MARK comment should be in valid format.
   - mark
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,6 +26,9 @@ only_rules:
   # Prefer `contains` over `first(where:) != nil`.
   - contains_over_first_not_nil
 
+  # Prefer `contains` over `range(of:) != nil` and `range(of:) == nil`.
+  - contains_over_range_nil_comparison
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -69,6 +69,9 @@ only_rules:
   # `if let foo = foo`).
   - shorthand_optional_binding
 
+  # Prefer `min(by:)` / `max(by:)` over `sorted { ... }.first` / `.last`.
+  - sorted_first_last
+
   # Files should have a single trailing newline.
   - trailing_newline
 


### PR DESCRIPTION
## Summary

Bundles ten zero-violation SwiftLint rule enables into a single PR to reduce reviewer churn.

All ten rules:

- have **0 violations** in the current codebase, so each is a `.swiftlint.yml`-only change;
- guard against the corresponding pattern landing in future code.

Rules in this bundle, one commit each:

- [`contains_over_filter_count`](https://realm.github.io/SwiftLint/contains_over_filter_count.html) — prefer `xs.contains { ... }` over `xs.filter { ... }.count > 0` (and `== 0` / `!= 0`).
- [`contains_over_first_not_nil`](https://realm.github.io/SwiftLint/contains_over_first_not_nil.html) — prefer `xs.contains { ... }` over `xs.first(where: ...) != nil`.
- [`contains_over_range_nil_comparison`](https://realm.github.io/SwiftLint/contains_over_range_nil_comparison.html) — prefer `s.contains(...)` over `s.range(of: ...) != nil`.
- [`first_where`](https://realm.github.io/SwiftLint/first_where.html) — prefer `xs.first { ... }` over `xs.filter { ... }.first`.
- [`last_where`](https://realm.github.io/SwiftLint/last_where.html) — prefer `xs.last { ... }` over `xs.filter { ... }.last`.
- [`sorted_first_last`](https://realm.github.io/SwiftLint/sorted_first_last.html) — prefer `min(by:)`/`max(by:)` over `sorted { ... }.first`/`.last`.
- [`reduce_into`](https://realm.github.io/SwiftLint/reduce_into.html) — prefer `reduce(into:_:)` over `reduce(_:_:)` for non-trivial accumulators.
- [`flatmap_over_map_reduce`](https://realm.github.io/SwiftLint/flatmap_over_map_reduce.html) — prefer `flatMap` over `map { ... }.reduce([], +)`.
- [`array_init`](https://realm.github.io/SwiftLint/array_init.html) — prefer `Array(xs)` over `xs.map { $0 }`.
- [`redundant_nil_coalescing`](https://realm.github.io/SwiftLint/redundant_nil_coalescing.html) — flag `?? nil` on a non-optional LHS.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Supersedes

- #344 — Enable SwiftLint rule: contains_over_filter_count
- #345 — Enable SwiftLint rule: contains_over_first_not_nil
- #346 — Enable SwiftLint rule: contains_over_range_nil_comparison
- #347 — Enable SwiftLint rule: first_where
- #348 — Enable SwiftLint rule: last_where
- #349 — Enable SwiftLint rule: sorted_first_last
- #350 — Enable SwiftLint rule: reduce_into
- #351 — Enable SwiftLint rule: flatmap_over_map_reduce
- #352 — Enable SwiftLint rule: array_init
- #353 — Enable SwiftLint rule: redundant_nil_coalescing

The superseded PRs will be closed with a backlink to this one.

`unneeded_parentheses_in_closure_argument` (#343) is **not** in this bundle — that branch carries autofixes to two source files and continues as its own PR.

## Test plan

- [ ] CI build is green.

🤖 Generated with [Claude Code](https://claude.ai/code)