### PR TITLE
Enable SwiftLint rule: vertical_whitespace_closing_braces

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -96,6 +96,9 @@ only_rules:
   # Unused parameters in closures should be replaced with `_`.
   - unused_closure_parameter
 
+  # Empty lines directly before a closing brace should be avoided.
+  - vertical_whitespace_closing_braces
+
   - custom_rules
 
 # Rules configuration

--- a/Tests/Tests/ABTesting/ExPlatTests.swift
+++ b/Tests/Tests/ABTesting/ExPlatTests.swift
@@ -88,7 +88,6 @@ class ExPlatTests: XCTestCase {
                 XCTAssertEqual(abTesting.experiment("experiment_multiple_variation"), .customTreatment(name: "another_treatment"))
                 expectation.fulfill()
             }
-
         }
 
         wait(for: [expectation], timeout: 2.0)

--- a/TracksDemo/TracksDemo Mac/AppDelegate.swift
+++ b/TracksDemo/TracksDemo Mac/AppDelegate.swift
@@ -11,6 +11,4 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ aNotification: Notification) {
         // Insert code here to tear down your application
     }
-
-
 }

--- a/TracksDemo/TracksDemo tvOS/ContentView.swift
+++ b/TracksDemo/TracksDemo tvOS/ContentView.swift
@@ -44,7 +44,6 @@ struct ContentView: View {
                     viewModel.load()
                 }
             }
-
         }
     }
 }


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`vertical_whitespace_closing_braces`](https://realm.github.io/SwiftLint/vertical_whitespace_closing_braces.html) rule.

The rule flags empty lines immediately before a closing brace, which add noise without aiding readability.

- 4 violations auto-fixed via `make format`.
- No manual rewrites needed.
- Local build + tests pass (iOS, `bundle exec fastlane ios test`).

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `make lint` is clean against the rule.

---

Generated with the help of Claude Code, https://claude.com/claude-code