### PR TITLE
Fix typos in comments

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
             ]
         ),
 
-        // This target is seperated out to reduce the number of other
+        // This target is separated out to reduce the number of other
         // dependencies included as part of the other targets.
         .library(
             name: "AutomatticEncryptedLogs",

--- a/Sources/Remote Logging/Crash Logging/CrashLogging.swift
+++ b/Sources/Remote Logging/Crash Logging/CrashLogging.swift
@@ -298,7 +298,7 @@ extension CrashLogging {
     /// Causes the Crash Logging System to refresh its knowledge about the current state of the system.
     ///
     /// This is required in situations like login / logout, when the system otherwise might not
-    /// know a change has occured.
+    /// know a change has occurred.
     ///
     /// Calling this method in these situations prevents
     public func setNeedsDataRefresh() {


### PR DESCRIPTION
## Description

Mechanical typo fixes in code comments and documentation — no behaviour change. Code identifiers and user-facing strings are untouched.

Each commit is one file, so the change is easy to review file by file.

## Testing instructions

No runtime impact — comment/doc-only. A green CI build is sufficient.

---

*Posted by Claude (Opus 4.8) on behalf of @mokagio with approval.*
