### PR TITLE
Store Tracks Core Data DB in Caches on tvOS

### DIFF
--- a/Sources/Model/ObjC/Common/Core Data/TracksContextManager.m
+++ b/Sources/Model/ObjC/Common/Core Data/TracksContextManager.m
@@ -92,28 +92,38 @@ NSString *const TracksPersistentStoreException      = @"TracksPersistentStoreExc
                                               attributes:nil
                                                    error:&error];
     
-    // It seems safe not to handle this error because Application Support should always be
-    // available and one should always be able to create a folder in it
+    // It should normally be safe not to handle this error because the store directory should always
+    // be available and one should always be able to create a folder in it
     if (error != nil) {
-        TracksLogError(@"Failed to create folder for %@ in Application Support: %@, %@", bundleIdentifier, error, [error userInfo]);
-        
+        TracksLogError(@"Failed to create the store directory for %@: %@, %@", bundleIdentifier, error, [error userInfo]);
+
         @throw [NSException exceptionWithName:TracksApplicationSupportException
-                                       reason:[NSString stringWithFormat:@"Error creating the ApplicationSupport Folder: %@", error]
+                                       reason:[NSString stringWithFormat:@"Error creating the store directory: %@", error]
                                      userInfo:error.userInfo];
-        
+
     }
     
     return folder;
 }
 
-// Application Support contains "the files that your app creates and manages on behalf of the user
-// and can include files that contain user data".
+// Returns the base directory under which the Tracks Core Data store is created.
 //
-// See:
-// https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html#//apple_ref/doc/uid/TP40010672-CH10-SW1
+// On most platforms this is Application Support, which "contains the files that your app creates and
+// manages on behalf of the user and can include files that contain user data".
+// See: https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html#//apple_ref/doc/uid/TP40010672-CH10-SW1
+//
+// tvOS is the exception: sandboxed apps may only write to Caches and the temporary directory, so
+// Application Support is unavailable there and trying to create the store in it throws. We fall back
+// to Caches on tvOS. Caches is purgeable, so the store is treated as a rebuildable cache, which is
+// fine for the Tracks event queue whose events are flushed to the server.
 - (NSURL *)applicationSupportURL {
-    // Application Support should always be available, so no checking whether the array is empty
-    return [[[NSFileManager defaultManager] URLsForDirectory:NSApplicationSupportDirectory
+    // The directory should always be available, so no checking whether the array is empty
+#if TARGET_OS_TV
+    NSSearchPathDirectory directory = NSCachesDirectory;
+#else
+    NSSearchPathDirectory directory = NSApplicationSupportDirectory;
+#endif
+    return [[[NSFileManager defaultManager] URLsForDirectory:directory
                                                    inDomains:NSUserDomainMask] lastObject];
 }
 

--- a/Sources/Model/ObjC/Common/Core Data/TracksContextManager.m
+++ b/Sources/Model/ObjC/Common/Core Data/TracksContextManager.m
@@ -76,16 +76,16 @@ NSString *const TracksPersistentStoreException      = @"TracksPersistentStoreExc
 }
 
 - (NSURL *)storeContainerDirectoryURL {
-    return [self applicationSupportURLForContainerApp];
+    return [self storeDirectoryURLForContainerApp];
 }
 
-- (NSURL *)applicationSupportURLForContainerApp {
+- (NSURL *)storeDirectoryURLForContainerApp {
     // The container app is the one owning the main bundle
-    return [self applicationSupportURLForAppWithBundleIdentifier:[[NSBundle mainBundle] bundleIdentifier]];
+    return [self storeDirectoryURLForAppWithBundleIdentifier:[[NSBundle mainBundle] bundleIdentifier]];
 }
 
-- (NSURL *)applicationSupportURLForAppWithBundleIdentifier:(NSString *)bundleIdentifier {
-    NSURL *folder = [[self applicationSupportURL] URLByAppendingPathComponent:bundleIdentifier];
+- (NSURL *)storeDirectoryURLForAppWithBundleIdentifier:(NSString *)bundleIdentifier {
+    NSURL *folder = [[self storeBaseDirectoryURL] URLByAppendingPathComponent:bundleIdentifier];
     NSError *error = nil;
     [[NSFileManager defaultManager] createDirectoryAtURL:folder
                              withIntermediateDirectories:true
@@ -116,7 +116,7 @@ NSString *const TracksPersistentStoreException      = @"TracksPersistentStoreExc
 // Application Support is unavailable there and trying to create the store in it throws. We fall back
 // to Caches on tvOS. Caches is purgeable, so the store is treated as a rebuildable cache, which is
 // fine for the Tracks event queue whose events are flushed to the server.
-- (NSURL *)applicationSupportURL {
+- (NSURL *)storeBaseDirectoryURL {
     // The directory should always be available, so no checking whether the array is empty
 #if TARGET_OS_TV
     NSSearchPathDirectory directory = NSCachesDirectory;

--- a/Tests/Tests/TracksContextManagerTests.swift
+++ b/Tests/Tests/TracksContextManagerTests.swift
@@ -3,10 +3,19 @@ import XCTest
 
 class TracksContextManagerTests: XCTestCase {
 
-    func testStoreIsInApplicationSupportDirectory() throws {
+    func testStoreIsInExpectedDirectory() throws {
         let contextManager = TracksContextManager()
         let storeURL = try getStoreURLFrom(contextManager)
+
+        // tvOS only allows apps to write to Caches and the temporary directory, so the store lives
+        // in Caches there instead of Application Support.
+        #if os(tvOS)
+        XCTAssertTrue(storeURL.pathComponents.contains("Caches"))
+        #else
         XCTAssertTrue(storeURL.pathComponents.contains("Application Support"))
+        #endif
+
+        XCTAssertEqual(storeURL.lastPathComponent, "Tracks.sqlite")
     }
 
     private func getStoreURLFrom(_ manager: TracksContextManager) throws -> URL {


### PR DESCRIPTION
### Problem

`TracksContextManager` creates its Core Data SQLite store under **Application Support**, which isn't writable on tvOS (only Caches and tmp are). On a real Apple TV, `TracksService` init throws `TracksApplicationSupportException` / `TracksPersistentStoreException`. The tvOS *Simulator* hides this (it inherits the Mac filesystem), so it only fails on device.

### Fix

Route the store's base directory to `NSCachesDirectory` on tvOS, keeping Application Support on every other platform. The store becomes `Library/Caches/<bundleid>/Tracks.sqlite` on tvOS. Caches is purgeable, which is fine for the transient Tracks event queue (events are flushed to the server). Also made the directory-creation error text platform-neutral and the store-directory test platform-aware.

### Testing

`testStoreIsInExpectedDirectory` passes on tvOS (store under Caches) and macOS (Application Support); `build-for-testing` succeeds for the tvOS Simulator.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
