### PR TITLE
Release 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,7 @@ _None._
 
 ### New Features
 
-- Track whether Lockdown Mode is enabled as a device property (`device_info_lockdown_mode_enabled`). [#331]
-- The library can now be used in tvOS targets. [#336]
+_None._
 
 ### Bug Fixes
 
@@ -48,6 +47,13 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 4.3.0
+
+### New Features
+
+- Track whether Lockdown Mode is enabled as a device property (`device_info_lockdown_mode_enabled`). [#331]
+- The library can now be used in tvOS targets. [#336]
 
 ## 4.2.1
 


### PR DESCRIPTION
## Changes in 4.3.0

### New Features

- Track whether Lockdown Mode is enabled as a device property (`device_info_lockdown_mode_enabled`). [#331]
- The library can now be used in tvOS targets. [#336]

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.