### PR TITLE
Make ExPlat.shared thread-safe

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,6 +20,14 @@ steps:
     plugins: [$CI_TOOLKIT_PLUGIN]
     artifact_paths: .build/logs/*.log
 
+  - label: "🧪 ExPlat Thread Sanitizer"
+    key: test_explat_tsan
+    command: |
+      install_gems
+      bundle exec fastlane ios test_explat_concurrency_tsan clean:true
+    plugins: [$CI_TOOLKIT_PLUGIN]
+    artifact_paths: .build/logs/*.log
+
   ######################
   # Build and Test macOS
   ######################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-- Made `ExPlat.shared` lifecycle thread-safe to fix a crash (`Cannot form weak reference to instance … of class AutomatticExperiments.ExPlat`) when `ExPlat` is reconfigured on a background queue while consumers read `ExPlat.shared` and call `refresh` concurrently. The public API is unchanged.
+- Made `ExPlat.shared` lifecycle thread-safe to fix a crash. [#364]
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Made `ExPlat.shared` lifecycle thread-safe to fix a crash (`Cannot form weak reference to instance … of class AutomatticExperiments.ExPlat`) when `ExPlat` is reconfigured on a background queue while consumers read `ExPlat.shared` and call `refresh` concurrently. The public API is unchanged.
 
 ### Internal Changes
 

--- a/Sources/Experiments/ExPlat.swift
+++ b/Sources/Experiments/ExPlat.swift
@@ -8,7 +8,19 @@ import Cocoa
 #endif
 
 @objc public class ExPlat: NSObject, ABTesting {
-    public static var shared: ExPlat!
+    private static let sharedLock = NSLock()
+    private static var _shared: ExPlat?
+
+    public static var shared: ExPlat! {
+        get {
+            sharedLock.lock(); defer { sharedLock.unlock() }
+            return _shared
+        }
+        set {
+            sharedLock.lock(); defer { sharedLock.unlock() }
+            _shared = newValue
+        }
+    }
 
     private let service: ExPlatService
 

--- a/Tests/Tests/ABTesting/ExPlatConcurrencyTests.swift
+++ b/Tests/Tests/ABTesting/ExPlatConcurrencyTests.swift
@@ -17,8 +17,8 @@ struct ExPlatConcurrencyTests {
         anonId: nil
     )
 
-    // Reassigning `ExPlat.shared` on a background queue while reading it must not crash
-    @Test func sharedLifecycleSurvivesConcurrentReassignmentAndReads() async {
+    @Test("Reassigning `ExPlat.shared` on a background queue while reading it must not crash")
+    func sharedLifecycleSurvivesConcurrentReassignmentAndReads() async {
         let iterations = 1_000
 
         _ = ExPlat(configuration: configuration, service: ExPlatServiceStub())

--- a/Tests/Tests/ABTesting/ExPlatConcurrencyTests.swift
+++ b/Tests/Tests/ABTesting/ExPlatConcurrencyTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+
+#if SWIFT_PACKAGE
+@testable import AutomatticExperiments
+#else
+@testable import AutomatticTracks
+#endif
+
+@Suite(.serialized)
+struct ExPlatConcurrencyTests {
+
+    private let configuration = ExPlatConfiguration(
+        platform: "wpios_test",
+        oAuthToken: nil,
+        userAgent: nil,
+        anonId: nil
+    )
+
+    // Reassigning `ExPlat.shared` on a background queue while reading it must not crash
+    @Test func sharedLifecycleSurvivesConcurrentReassignmentAndReads() async {
+        let iterations = 1_000
+
+        _ = ExPlat(configuration: configuration, service: ExPlatServiceStub())
+
+        await withCheckedContinuation { continuation in
+            let group = DispatchGroup()
+
+            // Reassign the global (releasing the previous instance) off the main thread
+            group.enter()
+            DispatchQueue.global().async {
+                for _ in 0..<iterations {
+                    _ = ExPlat(configuration: self.configuration, service: ExPlatServiceStub())
+                }
+                group.leave()
+            }
+
+            // Borrow the global and form `[weak self]` inside `refresh`
+            group.enter()
+            DispatchQueue.global().async {
+                for _ in 0..<iterations {
+                    ExPlat.shared?.refresh { }
+                    _ = ExPlat.shared?.experiment("experiment")
+                }
+                group.leave()
+            }
+
+            group.notify(queue: .global()) {
+                continuation.resume()
+            }
+        }
+
+        #expect(ExPlat.shared != nil)
+
+        ExPlat.shared = nil
+    }
+}
+
+// Resolves `refresh` synchronously without hitting the network
+private final class ExPlatServiceStub: ExPlatService {
+    init() {
+        super.init(configuration: ExPlatConfiguration(
+            platform: "wpios_test",
+            oAuthToken: nil,
+            userAgent: nil,
+            anonId: nil
+        ))
+    }
+
+    override func getAssignments(completion: @escaping (Assignments?) -> Void) {
+        completion(Assignments(ttl: 60, variations: ["experiment": "treatment"]))
+    }
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,8 +4,41 @@ BUILD_FOLDER = File.join(__dir__, '.build')
 BUILD_LOG_PATH = File.join(BUILD_FOLDER, 'logs')
 DERIVED_DATA_PATH = File.join(BUILD_FOLDER, 'derived-data')
 PROJECT_PATH = File.join(__dir__, 'TracksDemo', 'TracksDemo.xcodeproj')
+IOS_SCHEME = 'TracksDemo'
+MAC_SCHEME = 'TracksDemo Mac'
+IOS_TEST_DEVICE = 'iPhone 17'
+EXPLAT_CONCURRENCY_TEST_IDENTIFIER = 'AutomatticTracksTests/ExPlatConcurrencyTests'
 
 default_platform(:ios)
+
+def shared_test_options
+  {
+    project: PROJECT_PATH,
+    buildlog_path: BUILD_LOG_PATH,
+    derived_data_path: DERIVED_DATA_PATH
+  }
+end
+
+def run_ios_tests(clean:, **)
+  run_tests(
+    **shared_test_options,
+    scheme: IOS_SCHEME,
+    devices: [IOS_TEST_DEVICE],
+    prelaunch_simulator: true,
+    clean:,
+    skip_package_dependencies_resolution: !clean,
+    **
+  )
+end
+
+def run_macos_tests(clean:)
+  run_tests(
+    **shared_test_options,
+    scheme: MAC_SCHEME,
+    clean:,
+    skip_package_dependencies_resolution: !clean
+  )
+end
 
 before_all do
   # Bumping the interval Fastlane waits for xcodebuild to provide output before retrying.
@@ -14,35 +47,33 @@ before_all do
 end
 
 platform :ios do
-  desc 'Builds the project and runs tests'
-  lane :test do |options|
-    clean = options.fetch(:clean, false)
+  # Builds the project and runs tests.
+  #
+  # @param clean [Boolean] Build from a clean checkout and resolve Swift packages.
+  #
+  lane :test do |clean: false|
+    run_ios_tests(clean:)
+  end
 
-    run_tests(
-      scheme: 'TracksDemo',
-      project: PROJECT_PATH,
-      devices: ['iPhone 17'],
-      prelaunch_simulator: true,
-      buildlog_path: BUILD_LOG_PATH,
-      derived_data_path: DERIVED_DATA_PATH,
-      clean: clean,
-      skip_package_dependencies_resolution: !clean
+  # Runs the ExPlat shared lifecycle concurrency test with Thread Sanitizer enabled.
+  #
+  # @param clean [Boolean] Build from a clean checkout and resolve Swift packages.
+  #
+  lane :test_explat_concurrency_tsan do |clean: false|
+    run_ios_tests(
+      clean:,
+      thread_sanitizer: true,
+      only_testing: [EXPLAT_CONCURRENCY_TEST_IDENTIFIER]
     )
   end
 end
 
 platform :mac do
-  desc 'Builds the project and runs tests'
-  lane :test do |options|
-    clean = options.fetch(:clean, false)
-
-    run_tests(
-      scheme: 'TracksDemo Mac',
-      project: PROJECT_PATH,
-      buildlog_path: BUILD_LOG_PATH,
-      derived_data_path: DERIVED_DATA_PATH,
-      clean: clean,
-      skip_package_dependencies_resolution: !clean
-    )
+  # Builds the project and runs tests.
+  #
+  # @param clean [Boolean] Build from a clean checkout and resolve Swift packages.
+  #
+  lane :test do |clean: false|
+    run_macos_tests(clean:)
   end
 end


### PR DESCRIPTION
## Description

`ExPlat.shared` was a process-wide mutable global declared as a plain stored static var. The SDK **reassigns and releases** it on a background thread — every `ExPlat.configure(…)` builds a new instance whose `init` ends with `ExPlat.shared = self`, and consumers reach `configure` from background queues via `TracksService` user-switches — while consumers read `ExPlat.shared` and call `refresh` on the main thread, with no synchronization.

Because a *stored* static var hands call sites the value at +0 (no retain across the call), a reader can borrow an instance that a background `configure` then releases to refcount 0. The main-thread `refresh` forms `[weak self]` (`objc_initWeak`) on the dying instance and aborts:

```
SIGABRT: Cannot form weak reference to instance … of class AutomatticExperiments.ExPlat.
```

## Fix

Replace the stored static var with a lock-guarded computed property backed by private storage (`NSLock` + `_shared`). Two effects fix the crash:

1. A computed getter returns an **owned (+1)** value, so `ExPlat.shared?.refresh()` retains the instance for the duration of the call — eliminating the +0 borrow that allowed mid-`refresh` deallocation. No consumer code changes required.
2. The lock makes get/set atomic, so a reader never observes a torn/half-reassigned pointer and the release of the previous instance can't interleave with a read.

`NSLock` with explicit `lock()`/`defer unlock()` is used because the deployment targets (macOS 10.14 / iOS 15 / tvOS 15) predate `OSAllocatedUnfairLock` and `NSLock.withLock`. The public API and the `@objc` `configureWithPlatform:…` entry point are unchanged.

## Testing

- Added `ExPlatConcurrencyTests` (Swift Testing): repeatedly reassigns `ExPlat.shared` on a background queue while concurrently calling `refresh`/`experiment` on another, for 1000 iterations.
- Verified the test **reports a data race and fails** against the pre-fix stored var under Thread Sanitizer, and is **TSan-clean and passes** with the fix.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.