### PR TITLE
feat: support source-map debug images on JS exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- `JSException` can now provide source-map debug images (`debugImages`) so JavaScript exceptions symbolicate via Sentry Debug IDs, independent of on-device file paths. The property is optional (defaults to empty), so existing conformers are unaffected. [#373]
 
 ### Bug Fixes
 

--- a/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
+++ b/Sources/Remote Logging/Crash Logging/SentryEventJSException.swift
@@ -3,6 +3,11 @@ import Sentry
 
 public protocol JSException {
     associatedtype StacktraceLine: JSStacktraceLine
+    /// Source-map debug images that let Sentry symbolicate the minified stack
+    /// frames via Debug IDs, independent of the (unstable) on-device file paths.
+    /// Defaults to `NoJSDebugImage`, so existing conformers that don't provide
+    /// debug images keep compiling and behaving unchanged.
+    associatedtype DebugImage: JSDebugImage = NoJSDebugImage
     var type: String { get }
     var message: String { get }
     var stacktrace: [StacktraceLine] { get }
@@ -10,6 +15,12 @@ public protocol JSException {
     var tags: [String: String] { get }
     var isHandled: Bool { get }
     var handledBy: String { get }
+    var debugImages: [DebugImage] { get }
+}
+
+public extension JSException where DebugImage == NoJSDebugImage {
+    /// Conformers that don't specify a `DebugImage` type report no debug images.
+    var debugImages: [NoJSDebugImage] { [] }
 }
 
 public protocol JSStacktraceLine {
@@ -17,6 +28,23 @@ public protocol JSStacktraceLine {
     var function: String { get }
     var lineno: NSNumber? { get }
     var colno: NSNumber? { get }
+}
+
+/// A source-map debug image: pairs a minified file with the Debug ID that
+/// identifies its source map, so Sentry can look up the map by ID.
+public protocol JSDebugImage {
+    /// The minified file the debug ID applies to (matches the stack frame's file).
+    var codeFile: String { get }
+    /// The Debug ID shared by the minified file and its uploaded source map.
+    var debugID: String { get }
+}
+
+/// The default `JSException.DebugImage` type for conformers that supply no
+/// source-map debug images. Never instantiated (the default `debugImages` is
+/// always empty); it only satisfies the associated-type constraint.
+public struct NoJSDebugImage: JSDebugImage {
+    public var codeFile: String { "" }
+    public var debugID: String { "" }
 }
 
 public class SentryEventJSException: Event {
@@ -62,6 +90,20 @@ public class SentryEventJSException: Event {
         // Set event tags
         let tags = self.tags ?? [:]
         self.tags = tags.merging(jsException.tags) { $1 }
+
+        // Attach source-map debug images (if provided) so Sentry can match the
+        // uploaded source maps by Debug ID. This is required for JavaScript
+        // running from unstable on-device paths (e.g. a WebView loading files
+        // from a per-install bundle directory), where path-based matching fails.
+        if !jsException.debugImages.isEmpty {
+            self.debugMeta = jsException.debugImages.map {
+                let image = DebugMeta()
+                image.type = "sourcemap"
+                image.codeFile = $0.codeFile
+                image.debugID = $0.debugID
+                return image
+            }
+        }
     }
 
     override public func serialize() -> [String: Any] {
@@ -71,8 +113,13 @@ public class SentryEventJSException: Event {
         // Hence, we use the original platform set.
         serializedData["platform"] = self.platform
 
-        // Removing metadata associated with native exception, as it's not needed for JavaScript exceptions.
-        serializedData["debug_meta"] = nil
+        // Remove metadata associated with the native exception, as it's not
+        // needed for JavaScript exceptions. Preserve `debug_meta` when we've
+        // attached source-map debug images, since those are required to
+        // symbolicate the JavaScript stack trace.
+        if (self.debugMeta ?? []).isEmpty {
+            serializedData["debug_meta"] = nil
+        }
         serializedData["threads"] = nil
 
         return serializedData

--- a/Tests/Tests/SentryEventJSExceptionTests.swift
+++ b/Tests/Tests/SentryEventJSExceptionTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import Sentry
+
+#if SWIFT_PACKAGE
+@testable import AutomatticRemoteLogging
+#else
+@testable import AutomatticTracks
+#endif
+
+class SentryEventJSExceptionTests: XCTestCase {
+
+    func testSerializesSourceMapDebugImagesWhenProvided() throws {
+        let exception = MockJSException(debugImages: [
+            MockJSDebugImage(codeFile: "~/assets/index-abc123.js", debugID: "d552288e-c4cc-5fbc-b188-eec3bf468157")
+        ])
+
+        let serialized = SentryEventJSException(jsException: exception).serialize()
+
+        let debugMeta = try XCTUnwrap(serialized["debug_meta"] as? [String: Any])
+        let images = try XCTUnwrap(debugMeta["images"] as? [[String: Any]])
+        XCTAssertEqual(images.count, 1)
+        XCTAssertEqual(images[0]["type"] as? String, "sourcemap")
+        XCTAssertEqual(images[0]["code_file"] as? String, "~/assets/index-abc123.js")
+        XCTAssertEqual(images[0]["debug_id"] as? String, "d552288e-c4cc-5fbc-b188-eec3bf468157")
+    }
+
+    func testOmitsDebugMetaWhenNoDebugImagesProvided() {
+        // Mirrors the existing React Native path, which supplies no debug images:
+        // `debug_meta` must stay stripped so behavior is unchanged.
+        let exception = MockJSException(debugImages: [])
+
+        let serialized = SentryEventJSException(jsException: exception).serialize()
+
+        XCTAssertNil(serialized["debug_meta"])
+    }
+
+    func testDebugImagesDefaultsToEmptyForConformersThatDoNotProvideThem() {
+        // A conformer that doesn't implement `debugImages` relies on the protocol
+        // extension default, keeping existing conformers source-compatible.
+        let exception = LegacyJSException()
+
+        XCTAssertTrue(exception.debugImages.isEmpty)
+
+        let serialized = SentryEventJSException(jsException: exception).serialize()
+        XCTAssertNil(serialized["debug_meta"])
+    }
+}
+
+private struct MockJSDebugImage: JSDebugImage {
+    let codeFile: String
+    let debugID: String
+}
+
+private struct MockStacktraceLine: JSStacktraceLine {
+    var filename: String? = "~/assets/index-abc123.js"
+    var function: String = "boom"
+    var lineno: NSNumber? = 22
+    var colno: NSNumber? = 247
+}
+
+private struct MockJSException: JSException {
+    var type: String = "Error"
+    var message: String = "Boom"
+    var stacktrace: [MockStacktraceLine] = [MockStacktraceLine()]
+    var context: [String: Any] = [:]
+    var tags: [String: String] = [:]
+    var isHandled: Bool = false
+    var handledBy: String = "window.error"
+    var debugImages: [MockJSDebugImage]
+}
+
+/// A conformer that does NOT provide `debugImages`, exercising the protocol
+/// extension default (the React Native compatibility path).
+private struct LegacyJSException: JSException {
+    var type: String = "Error"
+    var message: String = "Boom"
+    var stacktrace: [MockStacktraceLine] = [MockStacktraceLine()]
+    var context: [String: Any] = [:]
+    var tags: [String: String] = [:]
+    var isHandled: Bool = false
+    var handledBy: String = "window.error"
+}


### PR DESCRIPTION
## What

Adds an optional way for `JSException`s to carry **source-map debug images**, so
JavaScript exceptions can be symbolicated in Sentry via **Debug IDs** rather than
by file path.

- New `JSDebugImage` protocol (`codeFile`, `debugID`).
- New optional `JSException.debugImages: [JSDebugImage]` property, defaulted to
  `[]` via a protocol extension.
- When a `JSException` provides debug images, `SentryEventJSException` attaches
  them as `type: "sourcemap"` entries on the event's `debug_meta`. `serialize()`
  now preserves `debug_meta` only when such images are present.

## Why

Consumers whose JavaScript runs from **unstable on-device paths** — e.g.
GutenbergKit, which loads editor JS in a `WKWebView` from a per-install bundle
directory (`file:///var/containers/Bundle/Application/<random-UUID>/…/assets/index-*.js`) —
cannot be symbolicated by Sentry's path-based source-map matching: the artifact
name can never equal a path containing a per-install random UUID.

Debug IDs solve this by matching a minified file to its source map via an
injected ID, independent of path or release. For that to work, the event must
carry the debug image, but `SentryEventJSException.serialize()` previously
stripped `debug_meta` unconditionally. This change lets a consumer supply the
debug images and have them reach Sentry.

## Backward compatibility

`debugImages` is optional with a `[]` default, so existing conformers (the React
Native / gutenberg-mobile path) require **no changes** and behave identically:
they supply no images, the array is empty, and `debug_meta` stays stripped
exactly as before.

## Testing

New `SentryEventJSExceptionTests` (all passing):
- With debug images → `serialize()` emits `debug_meta.images` with
  `type: "sourcemap"`, `code_file`, `debug_id`.
- Without debug images → `debug_meta` is absent (matches prior behavior).
- A conformer that doesn't implement `debugImages` gets the `[]` default.

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
