### PR TITLE
ci: AINFRA-3000: Use CI toolkit 6.3.0 for better artifact caching

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -4,7 +4,7 @@
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
 XCODE_VERSION=$(sed -E 's/^~> ?//' .xcode-version)
-CI_TOOLKIT_PLUGIN_VERSION="6.0.0"
+CI_TOOLKIT_PLUGIN_VERSION="6.3.0"
 
 export IMAGE_ID="xcode-$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"


### PR DESCRIPTION
The majors crossed (4.0.0, 5.0.0, 6.0.0) carry three breaking changes between them: pr_changed_files switching to exit codes, and two Windows-only script removals. Automattic-Tracks-iOS calls install_gems, so we're good.

As of ~~6.1.0~~ 6.1.1, CI toolkit uses the Synology NAS on-premises on the macOS queue, falling back to S3 only when that's not available, resulting in lower S3 hits.